### PR TITLE
Spikegen dims fix

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
-pip==19.2.3
+pip==21.1
 bump2version==0.5.11
 wheel==0.33.6
 watchdog==0.9.0

--- a/snntorch/spikegen.py
+++ b/snntorch/spikegen.py
@@ -497,6 +497,11 @@ def latency_code(
     if first_spike_time >= (num_steps - 1):
         raise Exception("`first_spike_time` must be less than `num_steps`-1.")
 
+    if first_spike_time and torch.max(data) > 1 and torch.min(data) < 0:
+        raise Exception(
+            "`first_spike_time` can only be applied to data between `0` and `1`."
+        )
+
     idx = data < threshold
 
     if not linear:

--- a/snntorch/spikegen.py
+++ b/snntorch/spikegen.py
@@ -83,7 +83,7 @@ def rate(
 
     """
 
-    if first_spike_time > (num_steps - 1):
+    if first_spike_time > (num_steps - 1) and num_steps:
         raise Exception(
             f"first_spike_time ({first_spike_time}) must be equal to or less than num_steps-1 ({num_steps-1})."
         )
@@ -95,6 +95,7 @@ def rate(
     if not num_steps:
         spike_data = rate_conv(data)
 
+        # zeros are added directly to the start of 0th (time) dimension
         if first_spike_time > 0:
             spike_data = torch.cat(
                 (
@@ -122,6 +123,7 @@ def rate(
 
         spike_data = rate_conv(time_data)
 
+        # zeros are multiplied by the start of the 0th (time) dimension
         if first_spike_time > 0:
             spike_data[0:first_spike_time] = 0
 

--- a/tests/test_spikegen.py
+++ b/tests/test_spikegen.py
@@ -30,6 +30,15 @@ def test_latency(test_input, expected):
 
 
 @pytest.mark.parametrize(
+    "test_input, expected", [(input_(0), (5.0, True)), (input_(1), (5.0, False))]
+)
+def test_latency_code(test_input, expected):
+    assert (
+        spikegen.latency_code(test_input, first_spike_time=5, num_steps=10) == expected
+    )
+
+
+@pytest.mark.parametrize(
     "test_input, expected",
     [(multi_input(1, 2, 2.91, 3, 3.9), multi_input(1, 1, 1, 0, 1))],
 )


### PR DESCRIPTION
* rate and rate_conv had dimensionality mismatch - this has now been fixed
* first_spike_time has been added to latency and rate
* rate: if num_steps is not specified, it is assumed that the input already has a time-dimension. A tensor of zeros where the 0th dim (time) = first_spike_time is concatenated to the start of spike_data
* rate: if num_steps is specified, it is assumed that the raw input is static. A tensor of zeros is multiplied by the start of the input. 
* latency: first_spike_time shifts the spike times in latency_code s.t. the first spike occurs at first_spike_time