### PR TITLE
Targets

### DIFF
--- a/docs/tutorials/tutorial_1.rst
+++ b/docs/tutorials/tutorial_1.rst
@@ -60,7 +60,7 @@ Let's define a few variables:
   data_path='/data/mnist'
   val_split = 0.1
   subset = 10
-  num_outputs = 10
+  num_classes = 10
 
   # Temporal Dynamics
   num_steps = 100
@@ -194,8 +194,7 @@ For an MNIST image, this probability corresponds to the pixel value. A white pix
   targets_it = targets_it.to(device)
 
   # Spiking Data
-  spike_data, spike_targets = spikegen.rate(data_it, targets_it, num_outputs=num_outputs, num_steps=num_steps,
-                                            gain=1, offset=0, one_hot=False, time_varying_targets=False)
+  spike_data = spikegen.rate(data_it, num_steps=num_steps, gain=1, offset=0)
       
 
 As you can see, :code:`spikegen.rate` takes a few arguments that can modify spiking probability:
@@ -206,11 +205,8 @@ As you can see, :code:`spikegen.rate` takes a few arguments that can modify spik
 If the result falls outside of [0,1], this no longer represents a probability. The result will automatically be clipped such that the feature represents a probability.
 
 .. note::
-  There are also options to convert targets to one hot encodings using :code:`one_hot`, and to extend the encodings along the time-axis using :code:`time_varying_targets`.
   
-  Both are set to :code:`False`, so :code:`targets_it` is simply passed directly to :code:`spike_targets` without any modification. We may also remove `targets_it` as an argument, and only return :code:`spike_data`. 
-  
-  For more detail on converting targets to spikes, please refer to the documentation of :code:`snntorch.spikegen` `here <https://snntorch.readthedocs.io/en/latest/snntorch.spikegen.html#snntorch.spikegen.targets_to_spikes>`_.
+There are numerous other options available for data conversion available. Fore more detail on converting input features (and targets) to spikes, please [refer to the documentation of `snntorch.spikegen` here](https://snntorch.readthedocs.io/en/latest/snntorch.spikegen.html#snntorch.spikegen.targets_to_spikes).
 
 The structure of the input data is :code:`[num_steps x batch_size x input dimensions]`:
 
@@ -267,7 +263,7 @@ The associated target label can be indexed as follows:
 
 ::
 
-  >>> print(f"The corresponding target is: {spike_targets[0]}")
+  >>> print(f"The corresponding target is: {targets_it[0]}")
 
   The corresponding target is: 3
 
@@ -275,7 +271,7 @@ As a matter of interest, let's do that again but with 25% of the gain to promote
 
 ::
 
-  spike_data = spikegen.rate(data_it, num_outputs=num_outputs, num_steps=num_steps, gain=0.25)
+  spike_data = spikegen.rate(data_it, num_steps, gain=0.25)
 
   spike_data_sample2 = spike_data[:, 0, 0]
   fig, ax = plt.subplots()
@@ -526,7 +522,7 @@ We can index into the corresponding target value to check what value it is.
 
 ::
 
-  >>> print(spike_targets[0])
+  >>> print(targets_it[0])
   tensor(4, device='cuda:0')
 
 
@@ -629,7 +625,7 @@ Although we have only shown :code:`spikegen.delta` on a fake sample of data, the
 
 That wraps up the three main spike conversion functions! There are still additional features to each of the three conversion techniques that have not been detailed in this tutorial. We recommend `referring to the documentation for a deeper dive <https://snntorch.readthedocs.io/en/latest/_modules/snntorch/spikegen.html>`_.
 
-3. Spike Generation
+1. Spike Generation
 ---------------------------------
 
 Now what if we don't actually have any data to start with? 

--- a/examples/tutorial_1_spikegen.ipynb
+++ b/examples/tutorial_1_spikegen.ipynb
@@ -16,8 +16,7 @@
         "xC96eesMqYo-",
         "mszPTrYOluym",
         "VTHK-wAWV57B"
-      ],
-      "toc_visible": true
+      ]
     },
     "kernelspec": {
       "name": "python3",
@@ -46,7 +45,7 @@
       "source": [
         "<img src='https://github.com/jeshraghian/snntorch/blob/master/docs/_static/img/snntorch_alpha_w.png?raw=true' width=\"400\">\n",
         "\n",
-        "# snnTorch - Spike Encoding and Visualization\n",
+        "# snnTorch - Spike Generation and Visualization with `spikegen` and `spikeplot`\n",
         "## Tutorial 1\n",
         "### By Jason K. Eshraghian (www.jasoneshraghian.com)\n",
         "\n",
@@ -160,7 +159,7 @@
         "data_path='/data/mnist'\n",
         "val_split = 0.1\n",
         "subset = 10\n",
-        "num_outputs = 10\n",
+        "num_classes = 10\n",
         "\n",
         "# Temporal Dynamics\n",
         "num_steps = 100\n",
@@ -205,6 +204,32 @@
         "mnist_train = datasets.MNIST(data_path, train=True, download=True, transform=transform)\n",
         "mnist_val = datasets.MNIST(data_path, train=True, download=True, transform=transform)\n",
         "mnist_test = datasets.MNIST(data_path, train=False, download=True, transform=transform)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "6ZyzEp9YHgPb"
+      },
+      "source": [
+        "If the above code blocks throws an error, e.g. the MNIST servers are down, then uncomment the following code instead."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "ZpGLLVqeHgwy"
+      },
+      "source": [
+        "# # temporary dataloader if MNIST service is unavailable\n",
+        "# !wget www.di.ens.fr/~lelarge/MNIST.tar.gz\n",
+        "# !tar -zxvf MNIST.tar.gz\n",
+        "\n",
+        "# mnist_train = datasets.MNIST(root = './', train=True, download=True, transform=transform)\n",
+        "# mnist_val = datasets.MNIST(root = './', train=True, download=True, transform=transform)\n",
+        "# mnist_test = datasets.MNIST(root = './', train=False, download=True, transform=transform)"
       ],
       "execution_count": null,
       "outputs": []
@@ -342,14 +367,14 @@
         "Spiking Neural Networks (SNNs) are made to exploit time-varying data. And yet, MNIST is not a time-varying dataset. \n",
         "This means that we have one of two options for passing input data into an SNN:\n",
         "\n",
-        "1. Directly feed the same static input features $x_i^{m}$ at each time step, where $x^{i}$ takes on an analog value $x^{i} \\in$  [0, 1].\n",
+        "1. For a single training sample $x^{(i)}$, directly feed the same static input features at each time step, where each element of $x^{(i)}$ takes on an analog value $x^{(i)}_n \\in$  [0, 1]. $n$ spans the number of inputs. \n",
         " This is like converting MNIST into a static, unchanging video.\n",
         "\n",
         "<center>\n",
         "<img src='https://github.com/jeshraghian/snntorch/blob/master/docs/_static/img/examples/tutorial1/1_2_1_static.png?raw=true' width=\"800\">\n",
         "</center>\n",
         "\n",
-        "2. Convert the input into a spike train of sequence length `num_steps`, where $x^{i}$ takes on a discrete value $x^{i}\n",
+        "2. Convert the input into a spike train of sequence length `num_steps`, where $x^{(i)}$ takes on a discrete value $x^{(i)}\n",
         " \\in$ {0, 1}.\n",
         "In this case, MNIST would become a time-varying sequence of spikes that are related to the original image.\n",
         "\n",
@@ -374,16 +399,16 @@
         "id": "3D5HSoY4bQDm"
       },
       "source": [
-        "### 2.1 Rate coding of MNIST\r\n",
-        "\r\n",
-        "Each input feature is used as the probability an event occurs, sampled from a binomial distribution. Formally, $X$~$B(n=1, p=x^{i})$ where the\r\n",
-        "**expected value** $\\mathbb E[X]=x^{i}$ is simply the probability that a spike is generated at any given time step.\r\n",
-        "\r\n",
-        "For an MNIST image, this probability corresponds to the pixel value. A white pixel corresponds to a 100% probability of spiking, and a black pixel will never generate a spike.\r\n",
-        "\r\n",
-        "\r\n",
-        "<center>\r\n",
-        "<img src='https://github.com/jeshraghian/snntorch/blob/master/docs/_static/img/examples/tutorial1/1_2_3_spikeconv.png?raw=true' width=\"1000\">\r\n",
+        "### 2.1 Rate coding of MNIST\n",
+        "\n",
+        "Each input feature is used as the probability an event occurs, sampled from a binomial distribution. Formally, **X** is a matrix of random variables and **X**~$B(n=1, p=x^{(i)})$ where the\n",
+        "**expected value** $\\mathbb E[$**X**$]=x^{(i)}$ is simply the probability that a spike is generated at any given time step.\n",
+        "\n",
+        "For an MNIST image, this probability corresponds to the pixel value. A white pixel corresponds to a 100% probability of spiking, and a black pixel will never generate a spike.\n",
+        "\n",
+        "\n",
+        "<center>\n",
+        "<img src='https://github.com/jeshraghian/snntorch/blob/master/docs/_static/img/examples/tutorial1/1_2_3_spikeconv.png?raw=true' width=\"1000\">\n",
         "</center>"
       ]
     },
@@ -405,8 +430,7 @@
         "targets_it = targets_it.to(device)\n",
         "\n",
         "# Spiking Data\n",
-        "spike_data, spike_targets = spikegen.rate(data_it, targets_it, num_outputs=num_outputs, num_steps=num_steps,\n",
-        "                                          gain=1, offset=0, one_hot=False, time_varying_targets=False)"
+        "spike_data = spikegen.rate(data_it, num_steps=num_steps, gain=1, offset=0)"
       ],
       "execution_count": null,
       "outputs": []
@@ -428,8 +452,7 @@
         "\n",
         "If the result falls outside of [0,1], this no longer represents a probability. The result will automatically be clipped such that the feature represents a probability.\n",
         "\n",
-        "Note: there are also options to convert targets to one hot encodings using `one_hot`, and to extend the encodings along the time-axis using `time_varying_targets`.\n",
-        "Both are set to `False`, so `targets_it` is simply passed directly to `spike_targets` without any modification. We may also remove `targets_it` as an argument, and only return `spike_data`. Fore more detail on converting targets to spikes, please [refer to the documentation of `snntorch.spikegen` here](https://snntorch.readthedocs.io/en/latest/snntorch.spikegen.html#snntorch.spikegen.targets_to_spikes).\n",
+        "There are numerous other options available for data conversion available. Fore more detail on converting input features (and targets) to spikes, please [refer to the documentation of `snntorch.spikegen` here](https://snntorch.readthedocs.io/en/latest/snntorch.spikegen.html#snntorch.spikegen.targets_to_spikes).\n",
         "\n",
         "The structure of the input data is ``[num_steps x batch_size x input dimensions]``:"
       ]
@@ -476,8 +499,8 @@
         "id": "4TYFlc4_ZK-u"
       },
       "source": [
-        "import matplotlib.pyplot as plt\r\n",
-        "import snntorch.spikeplot as splt\r\n",
+        "import matplotlib.pyplot as plt\n",
+        "import snntorch.spikeplot as splt\n",
         "from IPython.display import HTML"
       ],
       "execution_count": null,
@@ -572,7 +595,7 @@
         "id": "7Yb76uofobY4"
       },
       "source": [
-        "print(f\"The corresponding target is: {spike_targets[0]}\")"
+        "print(f\"The corresponding target is: {targets_it[0]}\")"
       ],
       "execution_count": null,
       "outputs": []
@@ -598,7 +621,7 @@
         "id": "ymxnM4CaobY5"
       },
       "source": [
-        "spike_data = spikegen.rate(data_it, num_outputs=num_outputs, num_steps=num_steps, gain=0.25)\n",
+        "spike_data = spikegen.rate(data_it, num_steps=num_steps, gain=0.25)\n",
         "\n",
         "spike_data_sample2 = spike_data[:, 0, 0]\n",
         "fig, ax = plt.subplots()\n",
@@ -753,16 +776,16 @@
         "id": "1lxp91nlobY-"
       },
       "source": [
-        "The idea of rate coding is actually quite controversial. Multiple spikes are needed to achieve any sort of task, and each spike consumes power. It is unlikely to be the only mechanism within the brain, which is both resource-constrained and highly efficient.\r\n",
-        "\r\n",
-        "We know that the reaction time of a human is around 250ms. If the averaging firing rate of a neuron in the human brain is on the order of 10Hz, then we can only process about 2 spikes within our reaction timescale.\r\n",
-        "\r\n",
-        "On the other hand, biological neurons are somewhat stochastic. In fact,  neurons fail to fire around 70% of the time that our idealized models would have us believe. Spike rate coding offsets the power disadvantage by showing huge noise robustness: it's fine if some of the spikes fail to generte, because there will be plenty more where they came from.\r\n",
-        "\r\n",
-        "Rate coding is almost certainly working in conjunction with other encoding schemes in the brain. We'll consider these other encoding mechanisms in the following sections. \r\n",
-        "\r\n",
-        "This covers the `spikegen.rate` function. Further information on [can be found in the documentation here](https://snntorch.readthedocs.io/en/latest/snntorch.spikegen.html).\r\n",
-        "\r\n"
+        "The idea of rate coding is actually quite controversial. Multiple spikes are needed to achieve any sort of task, and each spike consumes power. It is unlikely to be the only mechanism within the brain, which is both resource-constrained and highly efficient.\n",
+        "\n",
+        "We know that the reaction time of a human is around 250ms. If the averaging firing rate of a neuron in the human brain is on the order of 10Hz, then we can only process about 2 spikes within our reaction timescale.\n",
+        "\n",
+        "On the other hand, biological neurons are somewhat stochastic. In fact,  neurons fail to fire around 70% of the time that our idealized models would have us believe. Spike rate coding offsets the power disadvantage by showing huge noise robustness: it's fine if some of the spikes fail to generte, because there will be plenty more where they came from.\n",
+        "\n",
+        "Rate coding is almost certainly working in conjunction with other encoding schemes in the brain. We'll consider these other encoding mechanisms in the following sections. \n",
+        "\n",
+        "This covers the `spikegen.rate` function. Further information on [can be found in the documentation here](https://snntorch.readthedocs.io/en/latest/snntorch.spikegen.html).\n",
+        "\n"
       ]
     },
     {
@@ -1088,7 +1111,7 @@
         "id": "wrqfPu43obZE"
       },
       "source": [
-        "print(spike_targets[0])"
+        "print(targets_it[0])"
       ],
       "execution_count": null,
       "outputs": []
@@ -1099,19 +1122,19 @@
         "id": "Uxe0msNpmpcN"
       },
       "source": [
-        "### 2.4 Delta Modulation\r\n",
-        "There are theories that the retina is adaptive: it will only process information when there is something new to process. If there is no change in your field of view, then your photoreceptor cells will be much lesss prone to firing. \r\n",
-        "\r\n",
-        "That is to say: **biology is event-driven**. Our neurons thrive on change.\r\n",
-        "\r\n",
-        "As a nifty example, a few researchers have dedicated their lives to designing retina-inspired image sensors, for example, the [Dynamic Vision Sensor](https://ieeexplore.ieee.org/abstract/document/7128412/). Although [the attached link is from over a decade ago, the work in this video](https://www.youtube.com/watch?v=6eOM15U_t1M&ab_channel=TobiDelbruck) was clearly ahead of its time.\r\n",
-        "\r\n",
-        "Delta modulation is based on event-driven spiking. The `snntorch.delta` function accepts a time-series tensor as input. It takes the difference between each subsequent feature across all time steps. By default, if the difference is both *positive* and *greater than the threshold $V_{thr}$*, a spike is generated:\r\n",
-        "\r\n",
-        "<center>\r\n",
-        "<img src='https://github.com/jeshraghian/snntorch/blob/master/docs/_static/img/examples/tutorial1/1_2_7_delta.png?raw=true' width=\"600\">\r\n",
-        "</center>\r\n",
-        "\r\n",
+        "### 2.4 Delta Modulation\n",
+        "There are theories that the retina is adaptive: it will only process information when there is something new to process. If there is no change in your field of view, then your photoreceptor cells will be much lesss prone to firing. \n",
+        "\n",
+        "That is to say: **biology is event-driven**. Our neurons thrive on change.\n",
+        "\n",
+        "As a nifty example, a few researchers have dedicated their lives to designing retina-inspired image sensors, for example, the [Dynamic Vision Sensor](https://ieeexplore.ieee.org/abstract/document/7128412/). Although [the attached link is from over a decade ago, the work in this video](https://www.youtube.com/watch?v=6eOM15U_t1M&ab_channel=TobiDelbruck) was clearly ahead of its time.\n",
+        "\n",
+        "Delta modulation is based on event-driven spiking. The `snntorch.delta` function accepts a time-series tensor as input. It takes the difference between each subsequent feature across all time steps. By default, if the difference is both *positive* and *greater than the threshold $V_{thr}$*, a spike is generated:\n",
+        "\n",
+        "<center>\n",
+        "<img src='https://github.com/jeshraghian/snntorch/blob/master/docs/_static/img/examples/tutorial1/1_2_7_delta.png?raw=true' width=\"600\">\n",
+        "</center>\n",
+        "\n",
         "To illustrate, let's first come up with a contrived example where we create our own input tensor."
       ]
     },
@@ -1121,15 +1144,15 @@
         "id": "0AOr1kN-r4n-"
       },
       "source": [
-        "# Create a tensor with some fake time-series data\r\n",
-        "data = torch.Tensor([0, 1, 0, 2, 8, -20, 20, -5, 0, 1, 0])\r\n",
-        "\r\n",
-        "# Plot the tensor\r\n",
-        "plt.plot(data)\r\n",
-        "\r\n",
-        "plt.title(\"Some fake time-series data\")\r\n",
-        "plt.xlabel(\"Time step\")\r\n",
-        "plt.ylabel(\"Voltage (mV)\")\r\n",
+        "# Create a tensor with some fake time-series data\n",
+        "data = torch.Tensor([0, 1, 0, 2, 8, -20, 20, -5, 0, 1, 0])\n",
+        "\n",
+        "# Plot the tensor\n",
+        "plt.plot(data)\n",
+        "\n",
+        "plt.title(\"Some fake time-series data\")\n",
+        "plt.xlabel(\"Time step\")\n",
+        "plt.ylabel(\"Voltage (mV)\")\n",
         "plt.show()"
       ],
       "execution_count": null,
@@ -1150,20 +1173,20 @@
         "id": "WSNI1zGdtHac"
       },
       "source": [
-        "# Convert data\r\n",
-        "spike_data = spikegen.delta(data, threshold=4)\r\n",
-        "\r\n",
-        "# Create fig, ax\r\n",
-        "fig = plt.figure(facecolor=\"w\", figsize=(8, 1))\r\n",
-        "ax = fig.add_subplot(111)\r\n",
-        "\r\n",
-        "# Raster plot of delta converted data\r\n",
-        "splt.raster(spike_data, ax, c=\"black\")\r\n",
-        "\r\n",
-        "plt.title(\"Input Neuron\")\r\n",
-        "plt.xlabel(\"Time step\")\r\n",
-        "plt.yticks([])\r\n",
-        "plt.xlim(0, len(data))\r\n",
+        "# Convert data\n",
+        "spike_data = spikegen.delta(data, threshold=4)\n",
+        "\n",
+        "# Create fig, ax\n",
+        "fig = plt.figure(facecolor=\"w\", figsize=(8, 1))\n",
+        "ax = fig.add_subplot(111)\n",
+        "\n",
+        "# Raster plot of delta converted data\n",
+        "splt.raster(spike_data, ax, c=\"black\")\n",
+        "\n",
+        "plt.title(\"Input Neuron\")\n",
+        "plt.xlabel(\"Time step\")\n",
+        "plt.yticks([])\n",
+        "plt.xlim(0, len(data))\n",
         "plt.show()"
       ],
       "execution_count": null,
@@ -1175,8 +1198,8 @@
         "id": "dlmCwN40uPLq"
       },
       "source": [
-        "There are three time steps where the difference between $data[T]$ and $data[T+1]$ is greater than or equal to $V_{thr}=4$. This means there are three on-spikes. \r\n",
-        "\r\n",
+        "There are three time steps where the difference between $data[T]$ and $data[T+1]$ is greater than or equal to $V_{thr}=4$. This means there are three on-spikes. \n",
+        "\n",
         "The large dip to $-20$ has not been captured in our spikes. It might be the case that our data cares about negative swings as well, in which case we can enable the optional argument `off_spike=True`."
       ]
     },
@@ -1186,20 +1209,20 @@
         "id": "WMrUGhRnuN8e"
       },
       "source": [
-        "# Convert data\r\n",
-        "spike_data = spikegen.delta(data, threshold=4, off_spike=True)\r\n",
-        "\r\n",
-        "# Create fig, ax\r\n",
-        "fig = plt.figure(facecolor=\"w\", figsize=(8, 1))\r\n",
-        "ax = fig.add_subplot(111)\r\n",
-        "\r\n",
-        "# Raster plot of delta converted data\r\n",
-        "splt.raster(spike_data, ax, c=\"black\")\r\n",
-        "\r\n",
-        "plt.title(\"Input Neuron\")\r\n",
-        "plt.xlabel(\"Time step\")\r\n",
-        "plt.yticks([])\r\n",
-        "plt.xlim(0, len(data))\r\n",
+        "# Convert data\n",
+        "spike_data = spikegen.delta(data, threshold=4, off_spike=True)\n",
+        "\n",
+        "# Create fig, ax\n",
+        "fig = plt.figure(facecolor=\"w\", figsize=(8, 1))\n",
+        "ax = fig.add_subplot(111)\n",
+        "\n",
+        "# Raster plot of delta converted data\n",
+        "splt.raster(spike_data, ax, c=\"black\")\n",
+        "\n",
+        "plt.title(\"Input Neuron\")\n",
+        "plt.xlabel(\"Time step\")\n",
+        "plt.yticks([])\n",
+        "plt.xlim(0, len(data))\n",
         "plt.show()"
       ],
       "execution_count": null,
@@ -1211,8 +1234,8 @@
         "id": "S_5FajsDvnEw"
       },
       "source": [
-        "We've generated additional spikes, but this isn't actually the full picture! \r\n",
-        "\r\n",
+        "We've generated additional spikes, but this isn't actually the full picture! \n",
+        "\n",
         "If we print out the tensor, we will discover that we have actually generated \"off-spikes\". These spikes take on a value of `-1`."
       ]
     },
@@ -1233,8 +1256,8 @@
         "id": "-Nz32V0fxm2d"
       },
       "source": [
-        "Although we have only shown `spikegen.delta` on a fake sample of data, the true intention is to pass in time-series data and only generate an output when there has been a sufficiently large event. \r\n",
-        "\r\n",
+        "Although we have only shown `spikegen.delta` on a fake sample of data, the true intention is to pass in time-series data and only generate an output when there has been a sufficiently large event. \n",
+        "\n",
         "That wraps up the three main spike conversion functions! There are still additional features to each of the three conversion techniques that have not been detailed in this tutorial. We recommend [referring to the documentation for a deeper dive](https://snntorch.readthedocs.io/en/latest/_modules/snntorch/spikegen.html)."
       ]
     },

--- a/snntorch/spikegen.py
+++ b/snntorch/spikegen.py
@@ -67,13 +67,18 @@ def rate(
 
     """
 
-    if first_spike_time > (num_steps - 1) and (num_steps or not time_var_input):
-        raise Exception(
-            f"first_spike_time ({first_spike_time}) must be equal to or less than num_steps-1 ({num_steps-1})."
-        )
-
     if first_spike_time < 0 or num_steps < 0:
         raise Exception("``first_spike_time`` and ``num_steps`` cannot be negative.")
+
+    if first_spike_time > (num_steps - 1):
+        if num_steps:
+            raise Exception(
+                f"first_spike_time ({first_spike_time}) must be equal to or less than num_steps-1 ({num_steps-1})."
+            )
+        if not time_var_input:
+            raise Exception(
+                "If the input data is time-varying, set ``time_var_input=True``.\n If the input data is not time-varying, ensure ``num_steps > 0``."
+            )
 
     if first_spike_time > 0 and not time_var_input and not num_steps:
         raise Exception(

--- a/snntorch/spikegen.py
+++ b/snntorch/spikegen.py
@@ -953,7 +953,7 @@ def to_one_hot(targets, num_outputs):
     :rtype: torch.Tensor
     """
 
-    device = torch.device("cuda") if targets.is_cuda() else torch.device("cpu")
+    device = torch.device("cuda") if targets.is_cuda else torch.device("cpu")
 
     # Initialize zeros. E.g, for MNIST: (batch_size, 10).
     one_hot = torch.zeros([len(targets), num_outputs], device=device, dtype=dtype)

--- a/snntorch/spikegen.py
+++ b/snntorch/spikegen.py
@@ -75,7 +75,7 @@ def rate(
     if first_spike_time < 0:
         raise Exception("``first_spike_time`` cannot be negative.")
 
-    device = torch.device("cuda") if data.is_cuda() else torch.device("cpu")
+    device = torch.device("cuda") if data.is_cuda else torch.device("cpu")
 
     # intended for time-varying input data
     if time_var_input:
@@ -183,7 +183,7 @@ def latency(
         linear=linear,
     )
 
-    device = torch.device("cuda") if data.is_cuda() else torch.device("cpu")
+    device = torch.device("cuda") if data.is_cuda else torch.device("cpu")
 
     if not num_steps:
         num_steps = 1

--- a/snntorch/spikegen.py
+++ b/snntorch/spikegen.py
@@ -657,32 +657,30 @@ def targets_rate(
         )
 
         # create tensor of spike_targets for correct class
-        if correct_rate != 1:
-            correct_spike_targets, correct_spike_times = target_rate_code(
-                num_steps=num_steps,
-                first_spike_time=first_spike_time,
-                rate=correct_rate,
-                firing_pattern=firing_pattern,
-            )
-            correct_spikes_one_hot = one_hot_targets * correct_spike_targets.to(
-                device
-            ).unsqueeze(-1).unsqueeze(
-                -1
-            )  # the two unsquezes make the dims of correct_spikes num_steps x 1 x 1, s.t. time is broadcast in every other direction
+        correct_spike_targets, correct_spike_times = target_rate_code(
+            num_steps=num_steps,
+            first_spike_time=first_spike_time,
+            rate=correct_rate,
+            firing_pattern=firing_pattern,
+        )
+        correct_spikes_one_hot = one_hot_targets * correct_spike_targets.to(
+            device
+        ).unsqueeze(-1).unsqueeze(
+            -1
+        )  # the two unsquezes make the dims of correct_spikes num_steps x 1 x 1, s.t. time is broadcast in every other direction
 
         # create tensor of spike targets for incorrect class
-        if incorrect_rate != 0:
-            incorrect_spike_targets, incorrect_spike_times = target_rate_code(
-                num_steps=num_steps,
-                first_spike_time=first_spike_time,
-                rate=incorrect_rate,
-                firing_pattern=firing_pattern,
-            )
-            incorrect_spikes_one_hot = one_hot_inverse * incorrect_spike_targets.to(
-                device
-            ).unsqueeze(-1).unsqueeze(
-                -1
-            )  # the two unsquezes make the dims of correct_spikes num_steps x 1 x 1, s.t. time is broadcasted in every other direction
+        incorrect_spike_targets, incorrect_spike_times = target_rate_code(
+            num_steps=num_steps,
+            first_spike_time=first_spike_time,
+            rate=incorrect_rate,
+            firing_pattern=firing_pattern,
+        )
+        incorrect_spikes_one_hot = one_hot_inverse * incorrect_spike_targets.to(
+            device
+        ).unsqueeze(-1).unsqueeze(
+            -1
+        )  # the two unsquezes make the dims of correct_spikes num_steps x 1 x 1, s.t. time is broadcasted in every other direction
 
         # merge the incorrect and correct tensors
         if not interpolate:

--- a/snntorch/spikegen.py
+++ b/snntorch/spikegen.py
@@ -765,6 +765,23 @@ def target_rate_code(num_steps, first_spike_time=0, rate=1, firing_pattern="regu
     """
     Rate coding a single output neuron of tensor of length ``num_steps`` containing spikes, and another tensor containing the spike times.
 
+
+    Example::
+
+        spikegen.target_rate_code(num_steps=5, rate=1)
+        >>> (tensor([1., 1., 1., 1., 1.]), tensor([0, 1, 2, 3, 4]))
+
+        spikegen.target_rate_code(num_steps=5, first_spike_time=3, rate=1)
+        >>> (tensor([0., 0., 0., 1., 1.]), tensor([3, 4]))
+
+        spikegen.target_rate_code(num_steps=5, rate=0.3)
+        >>> (tensor([1., 0., 0., 1., 0.]), tensor([0, 3]))
+
+        spikegen.target_rate_code(num_steps=5, rate=0.3, firing_pattern="poisson")
+        >>> (tensor([0., 1., 0., 1., 0.]), tensor([1, 3]))
+
+
+
     :param num_steps: Number of time steps, defaults to ``False``
     :type num_steps: int, optional
 
@@ -830,6 +847,15 @@ def target_rate_code(num_steps, first_spike_time=0, rate=1, firing_pattern="regu
 def rate_interpolate(spike_times, num_steps, on_target=1, off_target=0, epsilon=1e-7):
     """Apply linear interpolation to a tensor of target spike times to enable gradual increasing membrane.
 
+    Example::
+
+        a = torch.Tensor([0, 4])
+        spikegen.rate_interpolate(a, num_steps=5)
+        >>> tensor([1.0000, 0.0000, 0.3333, 0.6667, 1.0000])
+
+        spikegen.rate_interpolate(a, num_steps=5, on_target=1.25, off_target=0.25)
+        >>> tensor([1.2500, 0.2500, 0.5833, 0.9167, 1.2500])
+
     :param spike_times: spike time targets in terms of steps
     :type targets: torch.Tensor
 
@@ -887,7 +913,15 @@ def rate_interpolate(spike_times, num_steps, on_target=1, off_target=0, epsilon=
 
 def to_one_hot_inverse(one_hot_targets):
     """Boolean inversion of a matrix of 1's and 0's.
-    Used to merge the targets of correct and incorrect neuron classes in ``targets_rate``."""
+    Used to merge the targets of correct and incorrect neuron classes in ``targets_rate``.
+
+    Example::
+
+        a = torch.Tensor([0, 0, 0, 0, 1])
+        spikegen.to_one_hot_inverse(a)
+        >>> tensor([[1., 1., 1., 1., 0.]])
+
+    """
 
     one_hot_inverse = one_hot_targets.clone()
     one_hot_inverse[one_hot_targets == 0] = 1

--- a/snntorch/spikegen.py
+++ b/snntorch/spikegen.py
@@ -598,7 +598,7 @@ def targets_rate(
     :rtype: torch.Tensor
     """
 
-    if not 0 < correct_rate < 1 or not 0 < incorrect_rate < 1:
+    if not 0 <= correct_rate <= 1 or not 0 <= incorrect_rate <= 1:
         raise Exception(
             f"``correct_rate``{correct_rate} and ``incorrect_rate``{incorrect_rate} must be between 0 and 1."
         )

--- a/snntorch/spikegen.py
+++ b/snntorch/spikegen.py
@@ -569,7 +569,7 @@ def latency_code_log(
 
 def _latency_errors(data, num_steps, threshold, tau, first_spike_time, normalize):
 
-    """Catches errors for spike time encoding latency functions ``latency_code_linear`` and ``latency_code_log``"""
+    """Catch errors for spike time encoding latency functions ``latency_code_linear`` and ``latency_code_log``"""
 
     if (
         threshold <= 0 or threshold >= 1

--- a/snntorch/spikegen.py
+++ b/snntorch/spikegen.py
@@ -218,6 +218,7 @@ def latency(
                 print_flag = False
             # spike_data = torch.clamp_max(spike_data, num_steps - 1)
             spike_time = torch.clamp_max(spike_time, num_steps - 1)
+            # spike_data = spike_data.scatter(0, torch.round(spike_time).long().unsqueeze(0), 1)
             clamp_flag = 1
 
     if clamp_flag == 1:
@@ -429,6 +430,7 @@ def latency_code(
             )
         if normalize:
             tau = num_steps - 1 - first_spike_time
+
         spike_time = (
             torch.clamp_max((-tau * (data - 1)), -tau * (threshold - 1))
             + first_spike_time
@@ -445,6 +447,7 @@ def latency_code(
     return spike_time, idx
 
 
+# rename - targets_convert, targets_code, targets_encode
 def targets_conv(
     targets,
     num_classes,
@@ -951,6 +954,11 @@ def to_one_hot(targets, num_classes):
     :return: one-hot encoding of targets of shape [batch x num_classes]
     :rtype: torch.Tensor
     """
+
+    if torch.max(targets > num_classes - 1):
+        raise Exception(
+            f"target [{torch.max(targets)}] is out of bounds for ``num_classes`` [{num_classes}]"
+        )
 
     device = torch.device("cuda") if targets.is_cuda else torch.device("cpu")
 

--- a/snntorch/spikegen.py
+++ b/snntorch/spikegen.py
@@ -72,8 +72,14 @@ def rate(
             f"first_spike_time ({first_spike_time}) must be equal to or less than num_steps-1 ({num_steps-1})."
         )
 
-    if first_spike_time < 0:
-        raise Exception("``first_spike_time`` cannot be negative.")
+    if first_spike_time < 0 or num_steps < 0:
+        raise Exception("``first_spike_time`` and ``num_steps`` cannot be negative.")
+
+    if first_spike_time > 0 and not time_var_input and not num_steps:
+        raise Exception(
+            "``num_steps`` must be specified if both the input is not time-varying and ``first_spike_time`` is greater than 0."
+        )
+        # output tensor is [0, B, D] # need to address that '0' in time-dim
 
     device = torch.device("cuda") if data.is_cuda else torch.device("cpu")
 

--- a/snntorch/spikegen.py
+++ b/snntorch/spikegen.py
@@ -611,7 +611,7 @@ def targets_rate(
     if incorrect_rate > correct_rate:
         raise Exception("``correct_rate`` must be greater than ``incorrect_rate``.")
 
-    if firing_pattern is not ("regular" or "uniform" or "poisson"):
+    if firing_pattern.lower() not in ["regular", "uniform", "poisson"]:
         raise Exception(
             "``firing_pattern`` must be either 'regular', 'uniform' or 'poisson'."
         )

--- a/tests/test_spikegen.py
+++ b/tests/test_spikegen.py
@@ -84,3 +84,102 @@ def test_target_rate2(test_input, expected):
             expected,
         )
     )
+
+
+@pytest.mark.parametrize(
+    "test_input, expected",
+    [(input_(4), input_([[0], [0.25], [0.5], [0.75], [1]]))],
+)
+def test_latency_interpolate(test_input, expected):
+    assert torch.all(
+        torch.eq(spikegen.latency_interpolate(test_input, num_steps=5), expected)
+    )
+
+
+# note: .squeeze(0) just makes it easier to parametrize from input_
+@pytest.mark.parametrize(
+    "test_input, expected",
+    [(input_([0, 1]), input_([[1, 0], [0, 1]]))],
+)
+def test_to_one_hot(test_input, expected):
+    assert torch.all(torch.eq(spikegen.to_one_hot(test_input.squeeze(0), 2), expected))
+
+
+@pytest.mark.parametrize(
+    "test_input, expected",
+    [(input_([0, 1]), input_([[0, 1], [1, 0]]))],
+)
+def test_to_one_hot_inverse(test_input, expected):
+    assert torch.all(
+        torch.eq(
+            spikegen.to_one_hot_inverse(spikegen.to_one_hot(test_input.squeeze(0), 2)),
+            expected,
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    "test_input, expected_1, expected_2",
+    [
+        (
+            input_([0, 1]),
+            input_([1.0, 0.0, 0.0, 0.0, 0.0]),
+            input_([0.0, 0.0, 0.0, 0.0, 1.0]),
+        )
+    ],
+)
+def test_targets_latency(test_input, expected_1, expected_2):
+    targets = spikegen.targets_latency(
+        test_input.squeeze(0), num_classes=2, num_steps=5, normalize=True
+    ).squeeze(0)
+    assert torch.all(torch.eq(targets[:, 0, 0], expected_1))
+    assert torch.all(torch.eq(targets[:, 0, 1], expected_2))
+
+
+@pytest.mark.parametrize(
+    "test_input, expected",
+    [(input_(4), input_([0, 0.25, 0.5, 0.75, 1]))],
+)
+def test_rate_interpolate(test_input, expected):
+    assert torch.all(
+        torch.eq(spikegen.rate_interpolate(test_input, num_steps=5), expected)
+    )
+
+
+@pytest.mark.parametrize(
+    "expected_1, expected_2",
+    [(input_([1, 0, 1, 0, 1]), input_([0, 2, 4]))],
+)
+def test_target_rate_code(expected_1, expected_2):
+    targets, idx = spikegen.target_rate_code(num_steps=5, rate=0.5)
+    assert torch.all(torch.eq(targets, expected_1))
+    assert torch.all(torch.eq(idx, expected_2))
+
+
+@pytest.mark.parametrize(
+    "test_input, expected",
+    [(input_([0, 1]), input_([2.99, 2.00]))],
+)
+def test_latency_code_linear(test_input, expected):
+    # assert torch.all(torch.eq(spikegen.latency_code_linear(torch.clamp(test_input, 0.01), num_steps=5, first_spike_time=2), expected))
+    assert torch.all(
+        torch.eq(
+            spikegen.latency_code_linear(test_input, num_steps=5, first_spike_time=2),
+            expected,
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    "test_input, expected",
+    [(input_([0, 1]), input_([14, 2]))],
+)
+def test_latency_code_log(test_input, expected):
+    assert torch.all(
+        torch.eq(
+            torch.round(
+                spikegen.latency_code_log(test_input, num_steps=5, first_spike_time=2)
+            ),
+            expected,
+        )
+    )

--- a/tests/test_spikegen.py
+++ b/tests/test_spikegen.py
@@ -30,6 +30,15 @@ def test_latency(test_input, expected):
 
 
 @pytest.mark.parametrize(
+    "test_input, expected", [(input_(0), (5.0, True)), (input_(1), (5.0, False))]
+)
+def test_latency_code(test_input, expected):
+    assert (
+        spikegen.latency_code(test_input, first_spike_time=5, num_steps=10) == expected
+    )
+
+
+@pytest.mark.parametrize(
     "test_input, expected",
     [(multi_input(1, 2, 2.91, 3, 3.9), multi_input(1, 1, 1, 0, 1))],
 )

--- a/tests/test_spikegen.py
+++ b/tests/test_spikegen.py
@@ -21,7 +21,12 @@ def identity(n):
 
 @pytest.mark.parametrize("test_input, expected", [(input_(0), 0), (input_(1), 1)])
 def test_rate(test_input, expected):
-    assert spikegen.rate(test_input) == expected
+    assert spikegen.rate(test_input, time_var_input=True) == expected
+
+
+@pytest.mark.parametrize("test_input, expected", [(input_(1), 2), (input_(0), 0)])
+def test_rate2(test_input, expected):
+    assert spikegen.rate(test_input, first_spike_time=3, num_steps=5).sum() == expected
 
 
 @pytest.mark.parametrize("test_input, expected", [(input_(0), 0), (input_(1), 1)])
@@ -47,16 +52,34 @@ def test_delta(test_input, expected):
 
 
 @pytest.mark.parametrize(
-    "test_input, expected", [(multi_input(0, 1, 2, 3, 4), identity(5))]
-)
-def test_targets_to_spikes(test_input, expected):
-    assert torch.all(
-        torch.eq(spikegen.targets_to_spikes(test_input, num_outputs=5), expected)
-    )
-
-
-@pytest.mark.parametrize(
     "test_input, expected", [(identity(5), (multi_input(0, 1, 2, 3, 4)))]
 )
 def test_from_one_hot(test_input, expected):
     assert torch.all(torch.eq(spikegen.from_one_hot(test_input), expected))
+
+
+@pytest.mark.parametrize(
+    "test_input, expected",
+    [(input_(4), multi_input(0, 0, 0, 0, 1))],
+)
+def test_target_rate(test_input, expected):
+    assert torch.all(
+        torch.eq(
+            spikegen.targets_conv(test_input, num_classes=5, code="rate"), expected
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    "test_input, expected",
+    [(input_(4), multi_input(0, 0, 1, 1, 1))],
+)
+def test_target_rate2(test_input, expected):
+    assert torch.all(
+        torch.eq(
+            spikegen.targets_conv(
+                test_input, num_classes=5, code="rate", num_steps=5, first_spike_time=2
+            )[:, 0, 4],
+            expected,
+        )
+    )

--- a/tests/test_spikegen.py
+++ b/tests/test_spikegen.py
@@ -29,18 +29,19 @@ def test_rate2(test_input, expected):
     assert spikegen.rate(test_input, first_spike_time=3, num_steps=5).sum() == expected
 
 
-@pytest.mark.parametrize("test_input, expected", [(input_(0), 0), (input_(1), 1)])
+@pytest.mark.parametrize("test_input, expected", [(input_(0), 1), (input_(1), 1)])
 def test_latency(test_input, expected):
-    assert spikegen.latency(test_input) == expected
+    assert spikegen.latency(test_input, bypass=True).sum() == expected
 
 
 @pytest.mark.parametrize(
-    "test_input, expected", [(input_(0), (5.0, True)), (input_(1), (5.0, False))]
+    "test_input, expected", [(input_(0), (16, True)), (input_(1), (5, False))]
 )
 def test_latency_code(test_input, expected):
-    assert (
-        spikegen.latency_code(test_input, first_spike_time=5, num_steps=10) == expected
+    spike_time, idx = spikegen.latency_code(
+        test_input, first_spike_time=5, num_steps=10
     )
+    assert tuple((spike_time.long(), idx)) == expected
 
 
 @pytest.mark.parametrize(
@@ -65,7 +66,7 @@ def test_from_one_hot(test_input, expected):
 def test_target_rate(test_input, expected):
     assert torch.all(
         torch.eq(
-            spikegen.targets_conv(test_input, num_classes=5, code="rate"), expected
+            spikegen.targets_convert(test_input, num_classes=5, code="rate"), expected
         )
     )
 
@@ -77,7 +78,7 @@ def test_target_rate(test_input, expected):
 def test_target_rate2(test_input, expected):
     assert torch.all(
         torch.eq(
-            spikegen.targets_conv(
+            spikegen.targets_convert(
                 test_input, num_classes=5, code="rate", num_steps=5, first_spike_time=2
             )[:, 0, 4],
             expected,


### PR DESCRIPTION
**revamped target conversion functions & fixed latency encoding mechanism**

* fixed latency sizing errors: latency now creates a new dimension in time; rate only creates a new dimension if targets are time-varying for more efficient memory usage
* added options to interpolate between spike encoded targets to enable smooth membrane targets instead
* added ``time_to_first_spike`` options for rate and latency encoding
* added irregular firing patterns to ``rate``
* added options to trigger incorrect classes to fire 
* use ``bypass`` argument in ``latency`` to enable 1) ``num_steps`` to be determined by final spike, or 2) for spikes outside the bounds of ``num_steps`` to be automatically clipped
* tutorial 1 updated to handle the above changes
* new tests added for all of the above mods