### PR TITLE
Temporal code

### DIFF
--- a/docs/snntorch.rst
+++ b/docs/snntorch.rst
@@ -21,7 +21,9 @@ The discrete nature of spikes makes it difficult for ``torch.autograd`` to calcu
 At present, the neurons available in :mod:`snntorch` are variants of the Leaky Integrate-and-Fire neuron model:
 
 * **Leaky** - 1st-Order Leaky Integrate-and-Fire Neuron
+* **RLeaky** - As above, with recurrent connections for output spikes
 * **Synaptic** - 2nd-Order Integrate-and-Fire Neuron (including synaptic conductance)
+* **RSynaptic** - As above, with recurrent connections for output spikes
 * **Lapicque** - Lapicque's RC Neuron Model
 * **Alpha** - Alpha Membrane Model
 
@@ -163,6 +165,8 @@ In the event you wish to have a learnable decay rate for each neuron rather than
          spk_out, mem_out = net(data.view(batch_size, -1))
 
 
+The same approach as above can be used for implementing learnable thresholds, using ``learn_threshold=True``. 
+
 Each neuron has the option to inhibit other neurons within the same layer from firing. 
 This can be invoked by setting ``inhibition=True`` when instantiating the neuron layer.
 
@@ -189,7 +193,17 @@ This can be invoked by setting ``inhibition=True`` when instantiating the neuron
    :undoc-members:
    :show-inheritance:
 
+.. automodule:: snntorch._neurons.rleaky
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 .. automodule:: snntorch._neurons.synaptic
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: snntorch._neurons.rsynaptic
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/snntorch.rst
+++ b/docs/snntorch.rst
@@ -10,12 +10,10 @@ A variety of spiking neuron classes are available which can simply be treated as
 Each layer of spiking neurons are therefore agnostic to fully-connected layers, convolutional layers, residual connections, etc. 
 
 The neuron models are represented by recursive functions which removes the need to store membrane potential traces in order to calculate the gradient. 
-This eliminates the need to store traces of hidden states for all neurons to calculate the gradient. 
 The lean requirements of :mod:`snntorch` enable small and large networks to be viably trained on CPU, where needed. 
 Being deeply integrated with ``torch.autograd``, :mod:`snntorch` is able to take advantage of GPU acceleration in the same way as PyTorch.
 
-By default, PyTorch's autodifferentiation tools are unable to calculate the analytical derivative of the spiking neuron graph. 
-The discrete nature of spikes makes it difficult for ``torch.autograd`` to calculate a gradient that facilitates learning.
+By default, PyTorch's autodifferentiation mechanism in ``torch.autograd`` nulls the gradient signal of the spiking neuron graph due to non-differentiable spiking threshold functions.
 :mod:`snntorch` overrides the default gradient by using :mod:`snntorch.LIF.Heaviside`. Alternative options exist in :mod:`snntorch.surrogate`.
 
 At present, the neurons available in :mod:`snntorch` are variants of the Leaky Integrate-and-Fire neuron model:
@@ -31,6 +29,25 @@ At present, the neurons available in :mod:`snntorch` are variants of the Leaky I
 
 How to use snnTorch's neuron models
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The following arguments are common across all neuron models:
+
+* **beta** - decay rate of membrane potential, clipped between 0 and 1 during the forward-pass. Can be a single-value tensor (same decay for all neurons in a layer), or can be multi-valued (individual weights p/neuron in a layer. More complex neurons include additional parameters, such as **alpha**.
+* **threshold** - firing threshold of the neuron
+* **spike_grad** - surrogate gradient function (see :mod:`snntorch.surrogate`)
+* **init_hidden** - setting to ``True`` hides all neuron states as instance variables to reduce code complexity
+* **inhibition** - setting to ``True`` enables only the neuron with the highest membrane potential to fire in a dense layer (not for use in convs etc.)
+* **learn_beta** - setting to ``True`` enables the decay rate to be a learnable parameter
+* **learn_threshold** - setting to ``True`` enables the threshold to be a learnable parameter 
+* **reset_mechanism** - options include ``subtract`` (reset-by-subtraction), ``zero`` (reset-to-zero), and ``none`` (no reset mechanism: i.e., leaky integrator neuron)
+* **output** - if ``init_hidden=True``, the spiking neuron will only return the output spikes. Setting ``output=True`` enables the hidden state(s) to be returned as well. Useful when using ``torch.nn.sequential``. 
+
+Recurrent spiking neuron models, such as :mod:`snntorch.RLeaky` and :mod:`snntorch.RSynaptic` explicitly pass the output spike back to the input. 
+Such neurons include additional arguments:
+
+* **V** - Recurrent weight. Can be a single-valued tensor (same weight across all neurons in a layer), or multi-valued tensor (individual weights p/neuron in a layer).
+* **learn_V** - defaults to ``True``, which enables **V** to be a learnable parameter. 
+
 Spiking neural networks can be constructed using a combination of the ``snntorch`` and ``torch.nn`` packages.
 
 Example::
@@ -52,36 +69,36 @@ Example::
 
             # initialize layers
             self.fc1 = nn.Linear(num_inputs, num_hidden)
-            self.lif1 = snn.Synaptic(alpha=alpha, beta=beta)
+            self.lif1 = snn.Leaky(beta=beta)
             self.fc2 = nn.Linear(num_hidden, num_outputs)
-            self.lif2 = snn.Synaptic(alpha=alpha, beta=beta)
+            self.lif2 = snn.Leaky(beta=beta)
 
          def forward(self, x):
-            spk1, syn1, mem1 = self.lif1.init_synaptic(batch_size, num_hidden)
-            spk2, syn2, mem2 = self.lif2.init_synaptic(batch_size, num_outputs)
+            mem1 = self.lif1.init_leaky()
+            mem2 = self.lif2.init_leaky()
 
             spk2_rec = []  # Record the output trace of spikes
             mem2_rec = []  # Record the output trace of membrane potential
 
             for step in range(num_steps):
-                  cur1 = self.fc1(x)
-                  spk1, syn1, mem1 = self.lif1(cur1, syn1, mem1)
+                  cur1 = self.fc1(x.flatten(1))
+                  spk1, mem1 = self.lif1(cur1, mem1)
                   cur2 = self.fc2(spk1)
-                  spk2, syn2, mem2 = self.lif2(cur2, syn2, mem2)
+                  spk2, mem2 = self.lif2(cur2, mem2)
 
                   spk2_rec.append(spk2)
                   mem2_rec.append(mem2)
 
-            return torch.stack(spk2_rec, dim=0), torch.stack(mem2_rec, dim=0)
+            return torch.stack(spk2_rec), torch.stack(mem2_rec)
 
       net = Net().to(device)
 
-      output, mem_rec = net(data.view(batch_size, -1))
+      output, mem_rec = net(data)
 
-In the above example, all hidden states, ``spk``, ``syn``, and ``mem`` must be manually initialized for each layer.
+In the above example, the hidden state ``mem`` must be manually initialized for each layer.
 This can be overcome by automatically instantiating neuron hidden states by invoking ``init_hidden=True``. 
 
-In some cases (e.g., in real-time recurrent learning), it might be necessary to perform backward passes before all time steps have completed processing.
+In some cases (e.g., truncated backprop through time), it might be necessary to perform backward passes before all time steps have completed processing.
 This requires moving the time step for-loop out of the network and into the training-loop. 
 
 An example of this is shown below::
@@ -104,7 +121,7 @@ An example of this is shown below::
                           lif2).to(device)
 
       for step in range(num_steps):
-         spk_out, mem_out = net(data.view(batch_size, -1))
+         spk_out, mem_out = net(data)
 
 
 Setting the hidden states to instance variables is necessary for calling the backpropagation methods available in :mod:`snntorch.backprop`, or for calling :mod:`nn.Sequential` from PyTorch.
@@ -112,7 +129,8 @@ Setting the hidden states to instance variables is necessary for calling the bac
 Whenever a neuron is instantiated, it is added as a list item to the class variable :mod:`LIF.instances`. 
 This helps the functions in :mod:`snntorch.backprop` keep track of what neurons are being used in the network, and when they must be detached from the computation graph. 
 
-In the above examples, the decay rate of membrane potential :mod:`beta` is treated as a hyperparameter. But it can also be configured as a learnable parameter, as shown below::
+In the above examples, the decay rate of membrane potential :mod:`beta` is treated as a hyperparameter. 
+But it can also be configured as a learnable parameter, as shown below::
 
       import torch
       import torch.nn as nn
@@ -167,10 +185,8 @@ In the event you wish to have a learnable decay rate for each neuron rather than
 
 The same approach as above can be used for implementing learnable thresholds, using ``learn_threshold=True``. 
 
-Each neuron has the option to inhibit other neurons within the same layer from firing. 
-This can be invoked by setting ``inhibition=True`` when instantiating the neuron layer.
-
-.. warning:: invoking ``inhibition=True`` requires ``batch_size`` to also be passed as an argument to the neuron.
+Each neuron has the option to inhibit other neurons within the same dense layer from firing. 
+This can be invoked by setting ``inhibition=True`` when instantiating the neuron layer. It has not yet been implemented for networks other than fully-connected layers, so use with caution.
 
 
 .. automodule:: snntorch._neurons.lif

--- a/snntorch/_neurons/__init__.py
+++ b/snntorch/_neurons/__init__.py
@@ -1,12 +1,14 @@
 ###############################################################
 # When adding new neurons, update the following:              #
-# i) utils.py: reset(); _layer_check(), _layer_reset() etc.   #
-# ii) neurons_dict in backprop.py,                            #
-# iii) update __neuron__ & import below                       #
-# iv) unit tests in tests/test_snntorch.py                    #
+# i) create neuron in snntorch/_neurons/your_neuron.py        #
+# ii) utils.py: reset(); _layer_check(), _layer_reset() etc.  #
+# iii) neurons_dict in backprop.py,                           #
+# iv) update __neuron__ & import below                        #
+# v) unit tests in tests/test_snntorch.py                     #
+# vi) update docs: snntorch.rst                               #
 ###############################################################
 
-__neuron__ = ["alpha", "lapicque", "leaky", "rleaky", "synaptic"]
+__neuron__ = ["alpha", "lapicque", "leaky", "rleaky", "synaptic", "rsynaptic"]
 
 from .lif import LIF
 from .alpha import Alpha

--- a/snntorch/_neurons/alpha.py
+++ b/snntorch/_neurons/alpha.py
@@ -13,14 +13,6 @@ class Alpha(LIF):
 
     .. warning:: For a positive input current to induce a positive membrane response, ensure :math:`α > β`.
 
-    If `reset_mechanism = "subtract"`, then :math:`I_{\\rm exc}, I_{\\rm inh}` will both have `threshold` subtracted from them whenever the neuron emits a spike:
-
-    .. math::
-
-            I_{\\rm exc}[t+1] = (αI_{\\rm exc}[t] + I_{\\rm in}[t+1]) - R(αI_{\\rm exc}[t] + I_{\\rm in}[t+1]) \\\\
-            I_{\\rm inh}[t+1] = (βI_{\\rm inh}[t] - I_{\\rm in}[t+1]) - R(βI_{\\rm inh}[t] - I_{\\rm in}[t+1]) \\\\
-            U[t+1] = τ_{\\rm α}(I_{\\rm exc}[t+1] + I_{\\rm inh}[t+1])
-
     If `reset_mechanism = "zero"`, then :math:`I_{\\rm exc}, I_{\\rm inh}` will both be set to `0` whenever the neuron emits a spike:
 
     .. math::
@@ -65,6 +57,16 @@ class Alpha(LIF):
                 cur2 = self.fc2(spk1)
                 spk2, syn_exc2, syn_inh2, mem2 = self.lif2(cur2, syn_exc2, syn_inh2, mem2)
                 return syn_exc1, syn_inh1, mem1, spk1, syn_exc2, syn_inh2, mem2, spk2
+
+        # Too many state variables which becomes cumbersome, so the following is also an option:
+
+        alpha = 0.9
+        beta = 0.8
+
+        net = nn.Sequential(nn.Linear(num_inputs, num_hidden),
+                            snn.Alpha(alpha=alpha, beta=beta, init_hidden=True),
+                            nn.Linear(num_hidden, num_outputs),
+                            snn.Alpha(alpha=alpha, beta=beta, init_hidden=True, output=True))
 
 
     """

--- a/snntorch/backprop.py
+++ b/snntorch/backprop.py
@@ -127,6 +127,7 @@ def TBPTT(
         "mse_count_loss": [True, False],
         "ce_latency_loss": [True, False],
         "mse_temporal_loss": [True, False],
+        "ce_temporal_loss": [True, False],
     }  # note: when using mse_count_loss, the target spike-count should be for a truncated time, not for the full time
 
     reg_dict = {"l1_rate_sparsity": True}

--- a/snntorch/backprop.py
+++ b/snntorch/backprop.py
@@ -126,6 +126,7 @@ def TBPTT(
         "ce_count_loss": [True, False],
         "mse_count_loss": [True, False],
         "ce_latency_loss": [True, False],
+        "mse_temporal_loss": [True, False],
     }  # note: when using mse_count_loss, the target spike-count should be for a truncated time, not for the full time
 
     reg_dict = {"l1_rate_sparsity": True}

--- a/snntorch/functional/loss.py
+++ b/snntorch/functional/loss.py
@@ -322,6 +322,8 @@ class mse_membrane_loss(LossFunctions):
 
 # Use labels by default unless target_is_time = True
 class SpikeTime(nn.Module):
+    """Used by ce_temporal_loss and mse_temporal_loss to convert spike outputs into spike times."""
+
     def __init__(
         self,
         target_is_time=False,

--- a/snntorch/spikegen.py
+++ b/snntorch/spikegen.py
@@ -839,7 +839,15 @@ def targets_rate(
     # return a non time-varying tensor
     if correct_rate == 1 and incorrect_rate == 0:
         if first_spike_time == 0:
-            return torch.clamp(to_one_hot(targets, num_classes) * on_target, off_target)
+            if on_target > off_target:
+                return torch.clamp(
+                    to_one_hot(targets, num_classes) * on_target, off_target
+                )
+            else:
+                return (
+                    to_one_hot(targets, num_classes) * on_target
+                    + ~(to_one_hot(targets, num_classes)).bool() * off_target
+                )
 
         # return time-varying tensor: off up to first_spike_time, then correct classes are on after
         if first_spike_time > 0:


### PR DESCRIPTION
* `mse_temporal_loss` function added
Applies mean square error the first F spikes. Option for tolerance included, as well as passing labels to be converted into spike-time targets.

* `ce_temporal_loss` added
Applies cross entropy loss to an inversion of the first spike. Inversion options include -1 * x and 1/x which means maximizing the logit of the correct class corresponds to minimizing the correct neuron's firing time.

* `accuracy_temporal` added
Measures accuracy based on the occurrence of the first spike

* Updated docs for neurons & loss methods