### PR TITLE
Detach and Reset Spikes in RLeaky

### DIFF
--- a/snntorch/_neurons/rleaky.py
+++ b/snntorch/_neurons/rleaky.py
@@ -242,6 +242,8 @@ class RLeaky(LIF):
         for layer in range(len(cls.instances)):
             if isinstance(cls.instances[layer], RLeaky):
                 cls.instances[layer].mem.detach_()
+                cls.instances[layer].spk.detach_()
+
 
     @classmethod
     def reset_hidden(cls):
@@ -250,4 +252,5 @@ class RLeaky(LIF):
         Assumes hidden states have a batch dimension already."""
         for layer in range(len(cls.instances)):
             if isinstance(cls.instances[layer], RLeaky):
-                cls.instances[layer].mem = _SpikeTensor(init_flag=False)
+                cls.instances[layer].spk, cls.instances[layer].mem = cls.instances[layer].init_rleaky()
+


### PR DESCRIPTION
I noticed that for the `Rleaky` neurons the spike acts as an internal state but was not reset nor detached. I believe the spikes should be reset and detached similar to the membrane potential in `reset_hidden` and `detach_hidden`, respectively. This merge request adds support for resetting and detaching of the spikes.