### PR TITLE
fix a bug in tutorial 6

### DIFF
--- a/examples/tutorial_6_CNN.ipynb
+++ b/examples/tutorial_6_CNN.ipynb
@@ -666,7 +666,7 @@
         "    print(f\"Epoch {epoch}, Train Loss: {avg_loss.item():.2f}\")\n",
         "\n",
         "    # Test set accuracy\n",
-        "    test_acc = batch_accuracy(train_loader, net, num_steps)\n",
+        "    test_acc = batch_accuracy(test_loader, net, num_steps)\n",
         "    test_acc_hist.append(test_acc)\n",
         "\n",
         "    print(f\"Epoch {epoch}, Test Acc: {test_acc * 100:.2f}%\\n\")"


### PR DESCRIPTION
train_loader should be test_loader in Sec. 3.3.
Original code
```
test_acc = batch_accuracy(train_loader, net, num_steps)
```