### PR TITLE
Graded spikes layer

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,4 +30,5 @@ test = pytest
 
 [tool:pytest]
 testpaths = tests
-collect_ignore = ['setup.py']
+# collect_ignore = ['setup.py']
+addopts = --ignore=setup.py

--- a/snntorch/_layers/__init__.py
+++ b/snntorch/_layers/__init__.py
@@ -1,8 +1,6 @@
-__layer__ = [
-    "BatchNormTT1d",
-    "BatchNormTT2d"
-]
+__layer__ = ["BatchNormTT1d", "BatchNormTT2d" "GradedSpikes"]
 
 from .bntt import *
+from .graded_spikes import *
 
 # from .slstm import SLSTM

--- a/snntorch/_layers/graded_spikes.py
+++ b/snntorch/_layers/graded_spikes.py
@@ -5,6 +5,17 @@ class GradedSpikes(torch.nn.Module):
     """Learnable spiking magnitude for spiking layers."""
 
     def __init__(self, size, constant_factor):
+        """
+
+        :param size: The input size of the layer. Must be equal to the
+        number of neurons in the preceeding layer.
+        :type size: int
+        :param constant_factor: If provided, the weights will be
+        initialized with ones times the contant_factor. If
+        not provided, the weights will be initialized using a uniform
+        distribution U(0.5, 1.5).
+        :type constant_factor: float
+        """
         super().__init__()
         self.size = size
 

--- a/snntorch/_layers/graded_spikes.py
+++ b/snntorch/_layers/graded_spikes.py
@@ -4,16 +4,16 @@ import torch
 class GradedSpikes(torch.nn.Module):
     """Learnable spiking magnitude for spiking layers."""
 
-    def __init__(self, size, constant_factor=None):
+    def __init__(self, size, constant_factor):
         super().__init__()
         self.size = size
-        weights = torch.Tensor(size)
-        self.weights = torch.nn.Parameter(weights)
 
         if constant_factor:
-            torch.nn.init.ones_(tensor=self.weights) * constant_factor
+            weights = torch.ones(size=[size, 1]) * constant_factor
+            self.weights = torch.nn.Parameter(weights)
         else:
-            torch.nn.init.uniform_(tensor=self.weights, a=0.0, b=1.0)
+            weights = torch.rand(size=[size, 1]) + 0.5
+            self.weights = torch.nn.Parameter(weights)
 
     def forward(self, x):
         """Forward pass is simply: spikes 'x' * weights."""

--- a/snntorch/_layers/graded_spikes.py
+++ b/snntorch/_layers/graded_spikes.py
@@ -1,0 +1,20 @@
+import torch
+
+
+class GradedSpikes(torch.nn.Module):
+    """Learnable spiking magnitude for spiking layers."""
+
+    def __init__(self, size, constant_factor=None):
+        super().__init__()
+        self.size = size
+        weights = torch.Tensor(size)
+        self.weights = torch.nn.Parameter(weights)
+
+        if constant_factor:
+            torch.nn.init.ones_(tensor=self.weights) * constant_factor
+        else:
+            torch.nn.init.uniform_(tensor=self.weights, a=0.0, b=1.0)
+
+    def forward(self, x):
+        """Forward pass is simply: spikes 'x' * weights."""
+        return torch.multiply(input=x, other=self.weights)

--- a/tests/test_snntorch/test_graded_spikes.py
+++ b/tests/test_snntorch/test_graded_spikes.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+
+"""Tests for graded spikes."""
+
+import pytest
+import snntorch as snn
+import torch
+
+
+@pytest.fixture(scope="module")
+def input_():
+    return torch.Tensor([0.0, 1.0, 2.0]).unsqueeze(-1)
+
+
+@pytest.fixture(scope="module")
+def graded_spikes_instance():
+    return snn.GradedSpikes(size=3, constant_factor=None)
+
+
+@pytest.fixture(scope="module")
+def graded_spikes_constant_factor_one_instance():
+    return snn.GradedSpikes(size=3, constant_factor=1.0)
+
+
+@pytest.fixture(scope="module")
+def graded_spikes_constant_factor_two_instance():
+    return snn.GradedSpikes(size=3, constant_factor=2.0)
+
+
+class TestLeaky:
+    def test_graded_spikes(self, graded_spikes_instance, input_):
+        out = graded_spikes_instance(input_)
+        assert False
+
+    def test_graded_spikes_constant_factor_one(
+        self, graded_spikes_constant_factor_one_instance, input_
+    ):
+        out = graded_spikes_constant_factor_one_instance(input_)
+        assert torch.all(torch.eq(input=input_, other=out))

--- a/tests/test_snntorch/test_graded_spikes.py
+++ b/tests/test_snntorch/test_graded_spikes.py
@@ -13,6 +13,11 @@ def input_():
 
 
 @pytest.fixture(scope="module")
+def label_():
+    return torch.Tensor([0.1, 1.1, 2.1]).unsqueeze(-1)
+
+
+@pytest.fixture(scope="module")
 def graded_spikes_instance():
     return snn.GradedSpikes(size=3, constant_factor=None)
 
@@ -29,11 +34,57 @@ def graded_spikes_constant_factor_two_instance():
 
 class TestLeaky:
     def test_graded_spikes(self, graded_spikes_instance, input_):
+        true = graded_spikes_instance.weights * input_
         out = graded_spikes_instance(input_)
-        assert False
+
+        assert torch.all(true == out)
+
+    def test_graded_spikes_learning(
+        self, graded_spikes_instance, input_, label_
+    ):
+
+        optimizer = torch.optim.AdamW(
+            graded_spikes_instance.parameters(),
+            lr=1e-3,
+            betas=(0.9, 0.999),
+            eps=1e-08,
+            weight_decay=0.01,
+        )
+        loss_function = torch.nn.MSELoss()
+        out = graded_spikes_instance(input_)
+        loss_start = loss_function(out, label_)
+
+        for i in range(100):
+            out = graded_spikes_instance(input_)
+            loss = loss_function(out, label_)
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+
+        assert loss < loss_start
+
+    def test_graded_spikes_shape(self, graded_spikes_instance, input_):
+        shapes_true = input_.shape
+        shapes_out = graded_spikes_instance(input_).shape
+
+        assert shapes_true == shapes_out
+
+    def test_graded_spikes_constant_shape(
+        self, graded_spikes_constant_factor_one_instance, input_
+    ):
+        shapes_true = input_.shape
+        shapes_out = graded_spikes_constant_factor_one_instance(input_).shape
+
+        assert shapes_true == shapes_out
 
     def test_graded_spikes_constant_factor_one(
         self, graded_spikes_constant_factor_one_instance, input_
     ):
         out = graded_spikes_constant_factor_one_instance(input_)
         assert torch.all(torch.eq(input=input_, other=out))
+
+    def test_graded_spikes_constant_factor_two(
+        self, graded_spikes_constant_factor_two_instance, input_
+    ):
+        out = graded_spikes_constant_factor_two_instance(input_)
+        assert torch.all(torch.eq(input=input_, other=0.5 * out))


### PR DESCRIPTION
This is the first try to implement a graded spikes layer. It takes an input (usually spikes from snnTorch neuronal layers) and scales them by simply multiplying (point-wise) it's weights with the input. The weights can be initialized using a constant factor, which results in all weights getting initialized with "ones * constant_factor". If no constant factor is provided, the weights are initialized with a uniform distribution U(0.5, 1.5). A lift of the standard uniform distribution U(0, 1) is carried out to avoid zero multiplication. The weights are trainable. Tests are provided to ensure the constant scaling works, the shapes are correct and the training works. Simple docstrings are provided.

This is a mere entry point into this topic, discussion is open!