### PR TITLE
Dataparallel fix

### DIFF
--- a/snntorch/_neurons/alpha.py
+++ b/snntorch/_neurons/alpha.py
@@ -119,9 +119,6 @@ class Alpha(LIF):
 
         if self.init_hidden:
             self.syn_exc, self.syn_inh, self.mem = self.init_alpha()
-            self.state_fn = self._build_state_function_hidden
-        else:
-            self.state_fn = self._build_state_function
 
         # if reset_mechanism == "subtract":
         #     self.mem_residual = False
@@ -146,7 +143,7 @@ class Alpha(LIF):
         # if hidden states are passed externally
         if not self.init_hidden:
             self.reset = self.mem_reset(mem)
-            syn_exc, syn_inh, mem = self.state_fn(
+            syn_exc, syn_inh, mem = self._build_state_function(
                 input_, syn_exc, syn_inh, mem
             )
 
@@ -168,7 +165,7 @@ class Alpha(LIF):
             self._alpha_forward_cases(mem, syn_exc, syn_inh)
 
             self.reset = self.mem_reset(self.mem)
-            self.syn_exc, self.syn_inh, self.mem = self.state_fn(input_)
+            self.syn_exc, self.syn_inh, self.mem = self._build_state_function_hidden(input_)
 
             if self.state_quant:
                 self.syn_exc = self.state_quant(self.syn_exc)

--- a/snntorch/_neurons/lapicque.py
+++ b/snntorch/_neurons/lapicque.py
@@ -210,9 +210,6 @@ class Lapicque(LIF):
 
         if self.init_hidden:
             self.mem = self.init_lapicque()
-            self.state_fn = self._build_state_function_hidden
-        else:
-            self.state_fn = self._build_state_function
 
     def forward(self, input_, mem=False):
 
@@ -225,7 +222,7 @@ class Lapicque(LIF):
 
         if not self.init_hidden:
             self.reset = self.mem_reset(mem)
-            mem = self.state_fn(input_, mem)
+            mem = self._build_state_function(input_, mem)
 
             if self.state_quant:
                 mem = self.state_quant(mem)
@@ -242,7 +239,7 @@ class Lapicque(LIF):
         if self.init_hidden:
             self._lapicque_forward_cases(mem)
             self.reset = self.mem_reset(self.mem)
-            self.mem = self.state_fn(input_)
+            self.mem = self._build_state_function_hidden(input_)
 
             if self.state_quant:
                 self.mem = self.state_quant(self.mem)

--- a/snntorch/_neurons/rleaky.py
+++ b/snntorch/_neurons/rleaky.py
@@ -257,9 +257,9 @@ class RLeaky(LIF):
 
         if self.init_hidden:
             self.spk, self.mem = self.init_rleaky()
-            self.state_fn = self._build_state_function_hidden
-        else:
-            self.state_fn = self._build_state_function
+        #     self.state_fn = self._build_state_function_hidden
+        # else:
+        #     self.state_fn = self._build_state_function
 
     def forward(self, input_, spk=False, mem=False):
         if hasattr(spk, "init_flag") or hasattr(
@@ -279,7 +279,7 @@ class RLeaky(LIF):
 
         if not self.init_hidden:
             self.reset = self.mem_reset(mem)
-            mem = self.state_fn(input_, spk, mem)
+            mem = self._build_state_function(input_, spk, mem)
 
             if self.state_quant:
                 mem = self.state_quant(mem)
@@ -296,7 +296,7 @@ class RLeaky(LIF):
         if self.init_hidden:
             self._rleaky_forward_cases(spk, mem)
             self.reset = self.mem_reset(self.mem)
-            self.mem = self.state_fn(input_)
+            self.mem = self._build_state_function_hidden(input_)
 
             if self.state_quant:
                 self.mem = self.state_quant(self.mem)

--- a/snntorch/_neurons/rsynaptic.py
+++ b/snntorch/_neurons/rsynaptic.py
@@ -267,9 +267,6 @@ class RSynaptic(LIF):
 
         if self.init_hidden:
             self.spk, self.syn, self.mem = self.init_rsynaptic()
-            self.state_fn = self._build_state_function_hidden
-        else:
-            self.state_fn = self._build_state_function
 
     def forward(self, input_, spk=False, syn=False, mem=False):
         if (
@@ -287,7 +284,7 @@ class RSynaptic(LIF):
 
         if not self.init_hidden:
             self.reset = self.mem_reset(mem)
-            syn, mem = self.state_fn(input_, spk, syn, mem)
+            syn, mem = self._build_state_function(input_, spk, syn, mem)
 
             if self.state_quant:
                 syn = self.state_quant(syn)
@@ -305,7 +302,7 @@ class RSynaptic(LIF):
         if self.init_hidden:
             self._rsynaptic_forward_cases(spk, mem, syn)
             self.reset = self.mem_reset(self.mem)
-            self.syn, self.mem = self.state_fn(input_)
+            self.syn, self.mem = self._build_state_function_hidden(input_)
 
             if self.state_quant:
                 self.syn = self.state_quant(self.syn)

--- a/snntorch/_neurons/sconv2dlstm.py
+++ b/snntorch/_neurons/sconv2dlstm.py
@@ -222,9 +222,6 @@ class SConv2dLSTM(SpikingNeuron):
 
         if self.init_hidden:
             self.syn, self.mem = self.init_sconv2dlstm()
-            self.state_fn = self._build_state_function_hidden
-        else:
-            self.state_fn = self._build_state_function
 
         self.in_channels = in_channels
         self.out_channels = out_channels
@@ -268,7 +265,7 @@ class SConv2dLSTM(SpikingNeuron):
 
         if not self.init_hidden:
             self.reset = self.mem_reset(mem)
-            syn, mem = self.state_fn(input_, syn, mem)
+            syn, mem = self._build_state_function(input_, syn, mem)
 
             if self.state_quant:
                 syn = self.state_quant(syn)
@@ -285,7 +282,7 @@ class SConv2dLSTM(SpikingNeuron):
         if self.init_hidden:
             # self._sconv2dlstm_forward_cases(mem, c)
             self.reset = self.mem_reset(self.mem)
-            self.syn, self.mem = self.state_fn(input_)
+            self.syn, self.mem = self._build_state_function_hidden(input_)
 
             if self.state_quant:
                 self.syn = self.state_quant(self.syn)

--- a/snntorch/_neurons/slstm.py
+++ b/snntorch/_neurons/slstm.py
@@ -183,9 +183,6 @@ class SLSTM(SpikingNeuron):
 
         if self.init_hidden:
             self.syn, self.mem = self.init_slstm()
-            self.state_fn = self._build_state_function_hidden
-        else:
-            self.state_fn = self._build_state_function
 
         self.input_size = input_size
         self.hidden_size = hidden_size
@@ -212,7 +209,7 @@ class SLSTM(SpikingNeuron):
 
         if not self.init_hidden:
             self.reset = self.mem_reset(mem)
-            syn, mem = self.state_fn(input_, syn, mem)
+            syn, mem = self._build_state_function(input_, syn, mem)
 
             if self.state_quant:
                 syn = self.state_quant(syn)
@@ -224,7 +221,7 @@ class SLSTM(SpikingNeuron):
         if self.init_hidden:
             # self._slstm_forward_cases(mem, syn)
             self.reset = self.mem_reset(self.mem)
-            self.syn, self.mem = self.state_fn(input_)
+            self.syn, self.mem = self._build_state_function_hidden(input_)
 
             if self.state_quant:
                 self.syn = self.state_quant(self.syn)

--- a/snntorch/_neurons/synaptic.py
+++ b/snntorch/_neurons/synaptic.py
@@ -180,9 +180,6 @@ class Synaptic(LIF):
 
         if self.init_hidden:
             self.syn, self.mem = self.init_synaptic()
-            self.state_fn = self._build_state_function_hidden
-        else:
-            self.state_fn = self._build_state_function
 
     def forward(self, input_, syn=False, mem=False):
 
@@ -199,7 +196,7 @@ class Synaptic(LIF):
 
         if not self.init_hidden:
             self.reset = self.mem_reset(mem)
-            syn, mem = self.state_fn(input_, syn, mem)
+            syn, mem = self._build_state_function(input_, syn, mem)
 
             if self.state_quant:
                 syn = self.state_quant(syn)
@@ -217,7 +214,7 @@ class Synaptic(LIF):
         if self.init_hidden:
             self._synaptic_forward_cases(mem, syn)
             self.reset = self.mem_reset(self.mem)
-            self.syn, self.mem = self.state_fn(input_)
+            self.syn, self.mem = self._build_state_function_hidden(input_)
 
             if self.state_quant:
                 self.syn = self.state_quant(self.syn)


### PR DESCRIPTION
Each neuron has had the object `state_fn` removed in the init function as it appeared to be triggering device errors.

@ridgerchu - could you check to make sure I've addressed the problem? 