### PR TITLE
Updated ce_max_membrane_loss() documentation

### DIFF
--- a/snntorch/functional/loss.py
+++ b/snntorch/functional/loss.py
@@ -181,6 +181,13 @@ class ce_max_membrane_loss(LossFunctions):
         loss_fn = SF.ce_max_membrane_loss()
         loss = loss_fn(outputs, targets)
 
+    :param mem_out: The output tensor of the SNN's membrane potential, of the dimension
+        timestep * batch_size * num_output_neurons
+    :type mem_out: torch.Tensor
+    :param targets: The tensor containing the targets of the current mini-batch, of the
+        dimension batch_size
+    :type targets: torch.Tensor
+
     :return: Loss
     :rtype: torch.Tensor (single element)
 


### PR DESCRIPTION
Updated snntorch.functional.ce_max_membrane_loss to be clearer with how the loss function expects its inputs