### PR TITLE
Fix graded_spikes registration

### DIFF
--- a/snntorch/_neurons/leaky.py
+++ b/snntorch/_neurons/leaky.py
@@ -154,12 +154,9 @@ class Leaky(LIF):
             reset_mechanism,
             state_quant,
             output,
-            graded_spikes_factor=1.0,
-            learn_graded_spikes_factor=False,
+            graded_spikes_factor,
+            learn_graded_spikes_factor,
         )
-        
-        self.graded_spikes_factor = torch.as_tensor(graded_spikes_factor)
-        self.learn_graded_spikes_factor = learn_graded_spikes_factor
 
         if self.init_hidden:
             self.mem = self.init_leaky()

--- a/tests/test_snntorch/test_leaky.py
+++ b/tests/test_snntorch/test_leaky.py
@@ -42,6 +42,13 @@ def leaky_hidden_reset_none_instance():
     return snn.Leaky(beta=0.5, init_hidden=True, reset_mechanism="none")
 
 
+@pytest.fixture(scope="module")
+def leaky_hidden_learn_graded_instance():
+    return snn.Leaky(
+        beta=0.5, init_hidden=True, learn_graded_spikes_factor=True
+    )
+
+
 class TestLeaky:
     def test_leaky(self, leaky_instance, input_):
         mem = leaky_instance.init_leaky()
@@ -117,3 +124,10 @@ class TestLeaky:
     def test_leaky_cases(self, leaky_hidden_instance, input_):
         with pytest.raises(TypeError):
             leaky_hidden_instance(input_, input_)
+
+    def test_leaky_hidden_learn_graded_instance(
+            self, leaky_hidden_learn_graded_instance
+    ):
+        factor = leaky_hidden_learn_graded_instance.graded_spikes_factor
+
+        assert factor.requires_grad


### PR DESCRIPTION
The standard values in Leaky had overwritten the graded spikes parameters. Removing them solved the issue. Added a test to check, if graded_spikes_factor is registered properly.