### PR TITLE
feat(neuron, synaptic): add missing args in example

### DIFF
--- a/snntorch/_neurons/synaptic.py
+++ b/snntorch/_neurons/synaptic.py
@@ -49,7 +49,7 @@ class Synaptic(LIF):
 
         # Define Network
         class Net(nn.Module):
-            def __init__(self):
+            def __init__(self, num_inputs, num_hidden, num_outputs):
                 super().__init__()
 
                 # initialize layers


### PR DESCRIPTION
The example was not running because missing some args (num_inputs, num_hidden, num_outputs); thus here I just add them.