### PR TITLE
Hashed static method above class Heaviside

### DIFF
--- a/snntorch/surrogate.py
+++ b/snntorch/surrogate.py
@@ -213,7 +213,7 @@ def atan(alpha=2.0):
     return inner
 
 
-@staticmethod
+# @staticmethod
 class Heaviside(torch.autograd.Function):
     """Default spiking function for neuron.
 


### PR DESCRIPTION
Dear Developers,

While using spike_grad = heaviside(), I encountered a below error:

AttributeError: 'staticmethod' object has no attribute 'apply'

I referred to the file surrogate.py and saw that staticmethod is written above to class Heaviside. That's why it gave me that error; I hashed it. If, it seems correct to you, please merge it into the existing code.


Regards
Abhishek