### PR TITLE
Fixed LSO Surrogate

### DIFF
--- a/snntorch/surrogate.py
+++ b/snntorch/surrogate.py
@@ -504,7 +504,7 @@ class LeakySpikeOperator(torch.autograd.Function):
         grad = (
             grad_input * out + (~out.bool()).float() * ctx.slope * grad_input
         )
-        return grad
+        return grad, None
 
 
 def LSO(slope=0.1):
@@ -512,7 +512,7 @@ def LSO(slope=0.1):
     slope = slope
 
     def inner(x):
-        return StochasticSpikeOperator.apply(x, slope)
+        return LeakySpikeOperator.apply(x, slope)
 
     return inner
 


### PR DESCRIPTION
The LSO method mistakenly used the StochasticSpikeOperator class. It has been corrected to use the LeakySpikeOperator class.

Additionally the backward method of the LeakySpikeOperator class only returned 1 value, when 2 are expected. None has been added as the second return value.

I don't have a proper dev environment to run the flak8 and black tests, so I hope it is ok if I don't include them. I figured that this is a simple two line bug fix, so it is easy to verify by eye. However, I did run training on my machine and it ran fine.