### PR TITLE
Tutorial variable name typo fix - spk_in to cur_in

### DIFF
--- a/examples/tutorial_2_lif_neuron.ipynb
+++ b/examples/tutorial_2_lif_neuron.ipynb
@@ -571,7 +571,7 @@
         "The neuron model is now stored in `lif1`. To use this neuron: \n",
         "\n",
         "**Inputs**\n",
-        "* `spk_in`: each element of $I_{\\rm in}$ is sequentially passed as an input (0 for now)\n",
+        "* `cur_in`: each element of $I_{\\rm in}$ is sequentially passed as an input (0 for now)\n",
         "* `mem`: the membrane potential, previously $U[t]$, is also passed as input. Initialize it arbitrarily as $U[0] = 0.9~V$.\n",
         "\n",
         "**Outputs**\n",


### PR DESCRIPTION
Fixed a typo in section 3.1 of the Tutorial 2 ipynb of `spk_in` to `cur_in` for the descriptions of the inputs to the neuron.