### PR TITLE
Tutorial 2 plot argument typo fix

### DIFF
--- a/docs/tutorials/tutorial_2.rst
+++ b/docs/tutorials/tutorial_2.rst
@@ -848,7 +848,7 @@ Run the following code block to see how many spikes have been generated.
     mem_rec = torch.stack(mem_rec)
     spk_rec = torch.stack(spk_rec)
     
-    plot_spk_mem_spk(spk_in, mem_rec, spk_out, "Lapicque's Neuron Model With Input Spikes")
+    plot_spk_mem_spk(spk_in, mem_rec, spk_rec, "Lapicque's Neuron Model With Input Spikes")
 
 
 .. image:: https://github.com/jeshraghian/snntorch/blob/master/docs/_static/img/examples/tutorial2/_static/spk_mem_spk.png?raw=true

--- a/examples/tutorial_2_lif_neuron.ipynb
+++ b/examples/tutorial_2_lif_neuron.ipynb
@@ -211,7 +211,7 @@
         "\n",
         "  plt.show()\n",
         "\n",
-        "def plot_spk_mem_spk(spk_in, mem, spk_out, title):\n",
+        "def plot_spk_mem_spk(spk_in, mem, spk_rec, title):\n",
         "  # Generate Plots\n",
         "  fig, ax = plt.subplots(3, figsize=(8,6), sharex=True, \n",
         "                        gridspec_kw = {'height_ratios': [0.4, 1, 0.4]})\n",
@@ -1334,7 +1334,7 @@
         "mem_rec = torch.stack(mem_rec)\n",
         "spk_rec = torch.stack(spk_rec)\n",
         "\n",
-        "plot_spk_mem_spk(spk_in, mem_rec, spk_out, \"Lapicque's Neuron Model With Input Spikes\")"
+        "plot_spk_mem_spk(spk_in, mem_rec, spk_rec, \"Lapicque's Neuron Model With Input Spikes\")"
       ]
     },
     {


### PR DESCRIPTION
Function `plot_spk_mem_spk` should take the argument of `spk_rec`, a variable used in the function instead of `spk_out`, which is not used in the function.