### PR TITLE
Update synaptic.py

### DIFF
--- a/snntorch/_neurons/synaptic.py
+++ b/snntorch/_neurons/synaptic.py
@@ -216,7 +216,7 @@ class Synaptic(LIF):
     def forward(self, input_, syn=None, mem=None):
 
         if not syn == None:
-            self.syn = mem
+            self.syn = syn
 
         if not mem == None:
             self.mem = mem


### PR DESCRIPTION
Fixed bug in `forward` method of `Synaptic` class when the argument `syn` is given.
Before this change, the variable `mem` was being assigned to `syn`, causing the synaptic current to explode.