### PR TITLE
MSE Temporal Loss Bugfix + Optimization

### DIFF
--- a/snntorch/functional/loss.py
+++ b/snntorch/functional/loss.py
@@ -542,7 +542,6 @@ class SpikeTime(nn.Module):
         @staticmethod
         def backward(ctx, grad_output):
             (first_spike_time, spk_rec) = ctx.saved_tensors
-            spk_time_grad = torch.zeros_like(spk_rec)  # T x B x N
 
             """spike extraction step/indexing @ each step is
             non-differentiable.
@@ -564,7 +563,7 @@ class SpikeTime(nn.Module):
 
             spk_time_grad[T_idx, B_idx, N_idx] = 1.0
             grad = -grad_output * spk_time_grad
-            
+
             return grad, None
 
     @staticmethod

--- a/snntorch/functional/loss.py
+++ b/snntorch/functional/loss.py
@@ -679,13 +679,8 @@ class SpikeTime(nn.Module):
         # TO-DO: remove ctx?
         @staticmethod
         def forward(ctx, spk_time, target, tolerance):
-            spk_time_clone = (
-                spk_time.clone()
-            )  # spk_time_clone: BxN (FxBxN for multi-spike); target: TxBxN
-            spk_time_clone[torch.abs(spk_time - target) < tolerance] = (
-                torch.ones_like(spk_time) * target
-            )[torch.abs(spk_time - target) < tolerance]
-            return spk_time_clone
+            mask = (spk_time - target).abs() <= tolerance
+            return torch.where(mask, target.to(spk_time.dtype), spk_time)
 
         @staticmethod
         def backward(ctx, grad_output):


### PR DESCRIPTION
Training a model with `mse_temporal_loss` would not work at all. Turns out the function `spikegen.targets_convert` used for converting target indices to spike times generates a tensor full of zeros, which would end up to be the target in MSE calculations. As a result, the model learns to spike all the outputs all the time.

Furthermore, training with `mse_temporal_loss` is also **very** slow. I changed the Python loops under `FirstSpike` to PyTorch functions without using loops. On my device, this leads to ~30x improvement in speed.