### PR TITLE
Fix: Forward pass logic on snn.synaptic neuron fix 

### DIFF
--- a/snntorch/_neurons/synaptic.py
+++ b/snntorch/_neurons/synaptic.py
@@ -216,7 +216,7 @@ class Synaptic(LIF):
     def forward(self, input_, syn=None, mem=None):
 
         if not syn == None:
-            self.syn = mem
+            self.syn = syn
 
         if not mem == None:
             self.mem = mem

--- a/snntorch/_neurons/synaptic.py
+++ b/snntorch/_neurons/synaptic.py
@@ -252,9 +252,9 @@ class Synaptic(LIF):
                 spk / self.graded_spikes_factor - self.reset
             )  # avoid double reset
             if self.reset_mechanism_val == 0:  # reset by subtraction
-                mem = mem - do_reset * self.threshold
+                self.mem = self.mem - do_reset * self.threshold
             elif self.reset_mechanism_val == 1:  # reset to zero
-                mem = mem - do_reset * mem
+                self.mem = self.mem - do_reset * self.mem
 
         if self.output:
             return spk, self.syn, self.mem


### PR DESCRIPTION
Fix bugs in `snn.Synaptic` forward pass. Mentioned in issues #358 #350 #349.

1. Synaptic Current was being assigned to the wrong variable (`self.syn = self.mem`)
2. The reset mechanism was not referencing the neuron's membrane potential variable properly (using `mem` instead of `self.mem`)

Pull Request #360 also takes care of the first issue so I included the original commit here