### PR TITLE
Fix bug of synaptic current update in Synaptic function

### DIFF
--- a/snntorch/_neurons/synaptic.py
+++ b/snntorch/_neurons/synaptic.py
@@ -216,7 +216,7 @@ class Synaptic(LIF):
     def forward(self, input_, syn=None, mem=None):
 
         if not syn == None:
-            self.syn = mem
+            self.syn = syn
 
         if not mem == None:
             self.mem = mem


### PR DESCRIPTION
snntorch/_neurons/synaptic.py
Line 219           self.syn = mem

Here is a typo, the update of synaptic current should based on the synaptic current of the last slot.
So, it should be changed to: 
Line 219           self.syn = syn