### PR TITLE
Fix spike/membrane potential independence

### DIFF
--- a/snntorch/_neurons/noisyleaky.py
+++ b/snntorch/_neurons/noisyleaky.py
@@ -11,6 +11,7 @@
 from .neurons import _SpikeTensor, _SpikeTorchConv, NoisyLIF
 import torch
 
+
 class NoisyLeaky(NoisyLIF):
     """
     Noisy leaky integrate-and-fire neuron model with noisy neuronal dynamics and probabilistic firing.
@@ -153,12 +154,13 @@ class NoisyLeaky(NoisyLIF):
             must be manually passed in, of shape `1` or`` (input_size).
 
     """
+
     def __init__(
         self,
         beta,
         threshold=1.0,
-        noise_type='gaussian',
-        noise_scale=0.3, 
+        noise_type="gaussian",
+        noise_scale=0.3,
         init_hidden=False,
         inhibition=False,
         learn_beta=False,
@@ -172,8 +174,8 @@ class NoisyLeaky(NoisyLIF):
         super(NoisyLeaky, self).__init__(
             beta,
             threshold,
-            noise_type, 
-            noise_scale, 
+            noise_type,
+            noise_scale,
             init_hidden,
             inhibition,
             learn_beta,
@@ -244,17 +246,17 @@ class NoisyLeaky(NoisyLIF):
                 return self.spk, self.mem
             else:  # hidden layer e.g., in nn.Sequential, only returns output
                 return self.spk
-            
+
     def fire(self, mem):
         r"""
-        Generate a spike using the probabilistic firing mechanism, i.e., if we still use mem to denote 
+        Generate a spike using the probabilistic firing mechanism, i.e., if we still use mem to denote
         the noise-free membrane potential, the firing probability is given by
-        
+
         P(firing) = P(mem+noise > threshold) = P(noise < mem-threshold) = CDF_noise(mem-threshold)
 
         spk ~ Bernoulli(P(firing))
-        :param mem: membrane voltage 
-        
+        :param mem: membrane voltage
+
         Returns spk
         """
         if self.state_quant:

--- a/snntorch/_neurons/noisyleaky.py
+++ b/snntorch/_neurons/noisyleaky.py
@@ -224,9 +224,7 @@ class NoisyLeaky(NoisyLIF):
         self.mem = self.beta.clamp(0, 1) * self.mem + input_
 
         if self.inhibition:
-            spk = self.fire_inhibition(
-                self.mem.size(0), self.mem
-            )  # batch_size
+            spk = self.fire_inhibition(self.mem.size(0), self.mem)  # batch_size
         else:
             spk = self.fire(self.mem)
 
@@ -282,46 +280,6 @@ class NoisyLeaky(NoisyLIF):
         # reset = spk.clone().detach()
 
         return spk
-
-    def _base_state_function(self, input_, mem):
-        base_fn = self.beta.clamp(0, 1) * mem + input_
-        return base_fn
-
-    def _build_state_function(self, input_, mem):
-        if self.reset_mechanism_val == 0:  # reset by subtraction
-            state_fn = self._base_state_function(
-                input_, mem - self.reset * self.threshold
-            )
-        elif self.reset_mechanism_val == 1:  # reset to zero
-            state_fn = self._base_state_function(
-                input_, mem
-            ) - self.reset * self._base_state_function(input_, mem)
-        elif self.reset_mechanism_val == 2:  # no reset, pure integration
-            state_fn = self._base_state_function(input_, mem)
-        return state_fn
-
-    def _base_state_function_hidden(self, input_):
-        base_fn = self.beta.clamp(0, 1) * self.mem + input_
-        return base_fn
-
-    def _build_state_function_hidden(self, input_):
-        if self.reset_mechanism_val == 0:  # reset by subtraction
-            state_fn = (
-                self._base_state_function_hidden(input_)
-                - self.reset * self.threshold
-            )
-        elif self.reset_mechanism_val == 1:  # reset to zero
-            self.mem = (1 - self.reset) * self.mem
-            state_fn = self._base_state_function_hidden(input_)
-        elif self.reset_mechanism_val == 2:  # no reset, pure integration
-            state_fn = self._base_state_function_hidden(input_)
-        return state_fn
-
-    def _leaky_forward_cases(self, mem):
-        if mem is not False:
-            raise TypeError(
-                "When `init_hidden=True`, Leaky expects 1 input argument."
-            )
 
     @classmethod
     def detach_hidden(cls):

--- a/tests/test_snntorch/test_noisyleaky.py
+++ b/tests/test_snntorch/test_noisyleaky.py
@@ -18,6 +18,11 @@ def noisyleaky_instance():
 
 
 @pytest.fixture(scope="module")
+def noisyleaky_reset_zero_output_instance():
+    return snn.NoisyLeaky(beta=0.5, reset_mechanism="zero", output=True)
+
+
+@pytest.fixture(scope="module")
 def noisyleaky_reset_zero_instance():
     return snn.NoisyLeaky(beta=0.5, reset_mechanism="zero")
 
@@ -139,3 +144,10 @@ class TestNoisyLeaky:
         factor = noisyleaky_hidden_learn_graded_instance.graded_spikes_factor
 
         assert factor.requires_grad
+
+    def test_noisyleaky_spike_reset_dependent(self, noisyleaky_reset_zero_output_instance):
+        steps = 30
+        mem = torch.zeros(1)
+        for t in range(steps):
+            spk, mem = noisyleaky_reset_zero_output_instance(torch.Tensor([[1.0]]), mem)
+            assert bool(spk) == (not bool(mem))

--- a/tests/test_snntorch/test_noisyleaky.py
+++ b/tests/test_snntorch/test_noisyleaky.py
@@ -55,15 +55,16 @@ def noisyleaky_hidden_learn_graded_instance():
 
 
 class TestNoisyLeaky:
-    def test_noisyleaky(self, noisyleaky_instance, input_):
-        mem = noisyleaky_instance.init_noisyleaky()
+    def test_noisyleaky(self, noisyleaky_reset_none_instance, input_):
+        # There is a small chance of the neuron spiking, so we need to use no reset version
+        mem = noisyleaky_reset_none_instance.init_noisyleaky()
 
         mem_rec = []
         spk_rec = []
 
         for i in range(2):
 
-            spk, mem = noisyleaky_instance(input_[i], mem)
+            spk, mem = noisyleaky_reset_none_instance(input_[i], mem)
             mem_rec.append(mem)
             spk_rec.append(spk)
 

--- a/tests/test_snntorch/test_noisyleaky.py
+++ b/tests/test_snntorch/test_noisyleaky.py
@@ -38,6 +38,13 @@ def noisyleaky_hidden_reset_zero_instance():
 
 
 @pytest.fixture(scope="function")
+def noisyleaky_hidden_reset_zero_output_instance():
+    return snn.NoisyLeaky(
+        beta=0.5, init_hidden=True, output=True, reset_mechanism="zero"
+    )
+
+
+@pytest.fixture(scope="function")
 def noisyleaky_hidden_reset_none_instance():
     return snn.NoisyLeaky(beta=0.5, init_hidden=True, reset_mechanism="none")
 
@@ -147,5 +154,15 @@ class TestNoisyLeaky:
         for t in range(steps):
             spk, mem = noisyleaky_reset_zero_instance(
                 torch.Tensor([[1.0]]), mem
+            )
+            assert bool(spk) == (not bool(mem))
+
+    def test_noisyleaky_hidden_spike_reset_dependent(
+        self, noisyleaky_hidden_reset_zero_output_instance
+    ):
+        steps = 30
+        for t in range(steps):
+            spk, mem = noisyleaky_hidden_reset_zero_output_instance(
+                torch.Tensor([[1.0]])
             )
             assert bool(spk) == (not bool(mem))

--- a/tests/test_snntorch/test_noisyleaky.py
+++ b/tests/test_snntorch/test_noisyleaky.py
@@ -7,47 +7,42 @@ import snntorch as snn
 import torch
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def input_():
     return torch.Tensor([0.25, 0]).unsqueeze(-1)
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def noisyleaky_instance():
     return snn.NoisyLeaky(beta=0.5)
 
 
-@pytest.fixture(scope="module")
-def noisyleaky_reset_zero_output_instance():
-    return snn.NoisyLeaky(beta=0.5, reset_mechanism="zero", output=True)
-
-
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def noisyleaky_reset_zero_instance():
     return snn.NoisyLeaky(beta=0.5, reset_mechanism="zero")
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def noisyleaky_reset_none_instance():
     return snn.NoisyLeaky(beta=0.5, reset_mechanism="none")
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def noisyleaky_hidden_instance():
     return snn.NoisyLeaky(beta=0.5, init_hidden=True)
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def noisyleaky_hidden_reset_zero_instance():
     return snn.NoisyLeaky(beta=0.5, init_hidden=True, reset_mechanism="zero")
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def noisyleaky_hidden_reset_none_instance():
     return snn.NoisyLeaky(beta=0.5, init_hidden=True, reset_mechanism="none")
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def noisyleaky_hidden_learn_graded_instance():
     return snn.NoisyLeaky(
         beta=0.5, init_hidden=True, learn_graded_spikes_factor=True
@@ -95,9 +90,7 @@ class TestNoisyLeaky:
         assert lif2.reset_mechanism_val == 2
         assert lif3.reset_mechanism_val == 0
 
-    def test_noisyleaky_init_hidden(
-        self, noisyleaky_hidden_instance, input_
-    ):
+    def test_noisyleaky_init_hidden(self, noisyleaky_hidden_instance, input_):
 
         spk_rec = []
 
@@ -140,15 +133,19 @@ class TestNoisyLeaky:
             noisyleaky_hidden_instance(input_, input_)
 
     def test_noisyleaky_hidden_learn_graded_instance(
-            self, noisyleaky_hidden_learn_graded_instance
+        self, noisyleaky_hidden_learn_graded_instance
     ):
         factor = noisyleaky_hidden_learn_graded_instance.graded_spikes_factor
 
         assert factor.requires_grad
 
-    def test_noisyleaky_spike_reset_dependent(self, noisyleaky_reset_zero_output_instance):
+    def test_noisyleaky_spike_reset_dependent(
+        self, noisyleaky_reset_zero_instance
+    ):
         steps = 30
         mem = torch.zeros(1)
         for t in range(steps):
-            spk, mem = noisyleaky_reset_zero_output_instance(torch.Tensor([[1.0]]), mem)
+            spk, mem = noisyleaky_reset_zero_instance(
+                torch.Tensor([[1.0]]), mem
+            )
             assert bool(spk) == (not bool(mem))


### PR DESCRIPTION
Here is a way that `NoisyLeaky` can work, resetting the membrane potential if and only if the neuron spikes.

Demo:
```
n = NoisyLeaky(beta=0.5, output=True, reset_mechanism="zero")

steps = 20
outs = []
mem = torch.zeros(1)
for t in range(steps):
    out, mem = n(torch.Tensor([[1.0]]), mem)
    outs.append((out, mem))

outs
```
![image](https://github.com/user-attachments/assets/86424e8e-d63c-4ed7-9e2a-5e559ae7bfbe)

```
lif2 = NoisyLeaky(beta=0.6)

# Initialize inputs and outputs
cur_in = torch.cat((torch.zeros(10, 1), torch.ones(190, 1)*0.2), 0)
mem = torch.zeros(1)
spk_out = torch.zeros(1) 
mem_rec = [mem]
spk_rec = [spk_out]

for ci in cur_in:
  spk_out, mem = lif2(ci, mem)
  mem_rec.append(mem)
  spk_rec.append(spk_out)

# convert lists to tensors
mem_rec = torch.stack(mem_rec)
spk_rec = torch.stack(spk_rec)

plot_cur_mem_spk(cur_in, mem_rec, spk_rec, thr_line=1, vline=109, ylim_max2=1.3)
```
![image](https://github.com/user-attachments/assets/5843ba1b-cfa3-40de-a285-321e0d2546e5)

That seems to make more sense to me.

I decided to change the mem output to reflect the value after spike/membrane reset in that step. Otherwise, I would have had to either make the class stateful or change the interface. Also, this just makes more sense to my brain. How does that play with the rest of the SNN world?

Cheers,
Leo