### PR TITLE
Fix: bug with clamp operation on Alpha neuron

### DIFF
--- a/snntorch/_neurons/alpha.py
+++ b/snntorch/_neurons/alpha.py
@@ -244,8 +244,8 @@ class Alpha(LIF):
 
     def _alpha_register_buffer(self, alpha, learn_alpha):
         if not isinstance(alpha, torch.Tensor):
-            self.alpha = torch.as_tensor(alpha)
-        self.alpha = self.alpha.clamp(0, 1)
+            alpha = torch.as_tensor(alpha)
+        self.alpha = alpha.clamp(0, 1)
         if learn_alpha:
             self.alpha = nn.Parameter(self.alpha)
         else:

--- a/snntorch/_neurons/alpha.py
+++ b/snntorch/_neurons/alpha.py
@@ -244,13 +244,12 @@ class Alpha(LIF):
 
     def _alpha_register_buffer(self, alpha, learn_alpha):
         if not isinstance(alpha, torch.Tensor):
-            alpha = torch.as_tensor(alpha)
-        if learn_alpha:
-            self.alpha = nn.Parameter(alpha)
-        else:
-            self.register_buffer("alpha", alpha)
-
+            self.alpha = torch.as_tensor(alpha)
         self.alpha = self.alpha.clamp(0, 1)
+        if learn_alpha:
+            self.alpha = nn.Parameter(self.alpha)
+        else:
+            self.register_buffer("alpha", self.alpha)
 
     def _alpha_cases(self):
         if (self.alpha <= self.beta).any():

--- a/snntorch/_neurons/alpha.py
+++ b/snntorch/_neurons/alpha.py
@@ -245,11 +245,11 @@ class Alpha(LIF):
     def _alpha_register_buffer(self, alpha, learn_alpha):
         if not isinstance(alpha, torch.Tensor):
             alpha = torch.as_tensor(alpha)
-        self.alpha = alpha.clamp(0, 1)
+        alpha = alpha.clamp(0, 1)
         if learn_alpha:
-            self.alpha = nn.Parameter(self.alpha)
+            self.alpha = nn.Parameter(alpha)
         else:
-            self.register_buffer("alpha", self.alpha)
+            self.register_buffer("alpha", alpha)
 
     def _alpha_cases(self):
         if (self.alpha <= self.beta).any():

--- a/snntorch/_neurons/rleaky.py
+++ b/snntorch/_neurons/rleaky.py
@@ -18,7 +18,7 @@ class RLeaky(LIF):
 
     .. math::
 
-            U[t+1] = βU[t] + I_{\\rm in}[t+1] + V(S_{\\rm out}[t]) -
+            U[t+1] = βU[t] + I_{\\rm in}[t+1] + VS_{\\rm out}[t] -
             RU_{\\rm thr}
 
     Where :math:`V(\\cdot)` acts either as a linear layer, a convolutional

--- a/snntorch/_neurons/rsynaptic.py
+++ b/snntorch/_neurons/rsynaptic.py
@@ -18,7 +18,7 @@ class RSynaptic(LIF):
 
     .. math::
 
-            I_{\\rm syn}[t+1] = αI_{\\rm syn}[t] + V(S_{\\rm out}[t]
+            I_{\\rm syn}[t+1] = αI_{\\rm syn}[t] + VS_{\\rm out}[t]
             + I_{\\rm in}[t+1] \\\\
             U[t+1] = βU[t] + I_{\\rm syn}[t+1] - RU_{\\rm thr}
 


### PR DESCRIPTION
There was a problem with the Alpha neuron; the clamp operation could not be performed on an nn.Parameter on GPU. To correct this, the clamp operation was performed before and is now working.

The error was:
```
    return Alpha(
  File "XXXX/.local/lib/python3.10/site-packages/snntorch/_neurons/alpha.py", line 119, in __init__
    self._alpha_register_buffer(alpha, learn_alpha)
  File "XXXX/.local/lib/python3.10/site-packages/snntorch/_neurons/alpha.py", line 252, in _alpha_register_buffer
    self.register_buffer("alpha", alpha)
  File "XXXX/.local/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1715, in __setattr__
    raise TypeError(f"cannot assign '{torch.typename(value)}' as parameter '{name}' "
TypeError: cannot assign 'torch.FloatTensor' as parameter 'alpha' (torch.nn.Parameter or None expected)
```