### PR TITLE
utlis.py data_subset incompatible indexing with PyTorch

### DIFF
--- a/snntorch/utils.py
+++ b/snntorch/utils.py
@@ -47,8 +47,8 @@ def data_subset(dataset, subset, idx=0):
         step = N // subset
         idx_range = idx_range[step * idx : step * (idx + 1)]
 
-        data = dataset.data[idx_range]
-        targets = dataset.targets[idx_range]
+        data = dataset.data[idx_range.tolist()]
+        targets = dataset.targets[idx_range.tolist()]
 
         dataset.data = data
         dataset.targets = targets


### PR DESCRIPTION
while I was running the Tutorial, i encountered this error
`---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
Cell In[20], line 4
      1 from snntorch import utils
      3 subset = 10
----> 4 mnist_train = utils.data_subset(dataset=mnist_train, subset=subset)
      5 print(f"The size of mnist_train is {len(mnist_train)}")

File c:\Users\andre\Documents\University\SNNs\doc_tutorial\.venv\Lib\site-packages\snntorch\utils.py:50, in data_subset(dataset, subset, idx)
     47 step = N // subset
     48 idx_range = idx_range[step * idx : step * (idx + 1)]
---> 50 data = dataset.data[idx_range]
     51 targets = dataset.targets[idx_range]
     53 dataset.data = data

RuntimeError: Could not infer dtype of numpy.int64`
which i could fix by changing the idx_range into list type