### PR TITLE
Fix rsynaptic error on GPU

### DIFF
--- a/snntorch/_neurons/rsynaptic.py
+++ b/snntorch/_neurons/rsynaptic.py
@@ -421,7 +421,7 @@ class RSynaptic(LIF):
             + input_
             + self.recurrent(self.spk)
         )
-        base_fn_mem = self.beta.clamp(0, 1) * self.mem + base_fn_syn
+        base_fn_mem = nn.Parameter(self.beta.clamp(0, 1)) * self.mem + base_fn_syn
         return base_fn_syn, base_fn_mem
 
     def _base_state_reset_zero(self, input_):
@@ -535,4 +535,4 @@ class RecurrentOneToOne(nn.Module):
         self.V = V
 
     def forward(self, x):
-        return x * self.V  # element-wise or global multiplication
+        return nn.Parameter(x * self.V)  # element-wise or global multiplication


### PR DESCRIPTION
The RSynaptic has two errors, that can be solved by using a nn.Parameter() object.
Here are the errors that were solved with this pull request:
```
File "XXXX/.local/lib/python3.10/site-packages/snntorch/_neurons/rsynaptic.py", line 425, in _base_state_function
    base_fn_mem = self.beta.clamp(0, 1) * self.mem + base_fn_syn
 (Triggered internally at ../torch/csrc/autograd/python_anomaly_mode.cpp:114.)
  Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass
one of the variables needed for gradient computation has been modified by an inplace operation: [torch.cuda.FloatTensor []] is at version 1; expected version 0 instead. Hint: the backtrace further above shows the operation that failed to compute its gradient. The variable in question was changed in there or anywhere later. Good luck!
```

```
File "XXXX/.local/lib/python3.10/site-packages/snntorch/_neurons/rsynaptic.py", line 538, in forward
    return x * self.V  # element-wise or global multiplication
 (Triggered internally at ../torch/csrc/autograd/python_anomaly_mode.cpp:114.)
  Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass
one of the variables needed for gradient computation has been modified by an inplace operation: [torch.cuda.FloatTensor []] is at version 1; expected version 0 instead. Hint: the backtrace further above shows the operation that failed to compute its gradient. The variable in question was changed in there or anywhere later. Good luck!
```