### PR TITLE
Correct definition of surrogate.LSO()

### DIFF
--- a/snntorch/surrogate.py
+++ b/snntorch/surrogate.py
@@ -512,7 +512,7 @@ def LSO(slope=0.1):
     slope = slope
 
     def inner(x):
-        return StochasticSpikeOperator.apply(x, slope)
+        return LeakySpikeOperator.apply(x, slope)
 
     return inner
 


### PR DESCRIPTION
The function `surrogate.LSO()` is incorrectly linked to class `StochasticSpikeOperator` instead of the correct `LeakySpikeOperator`.
This one-line PR corrects `surrogate.LSO()` to utilize the right class.
