### PR TITLE
nir: add back import for nir.IF node

### DIFF
--- a/snntorch/import_nir.py
+++ b/snntorch/import_nir.py
@@ -460,6 +460,7 @@ def import_from_nir(graph: nir.NIRGraph) -> torch.nn.Module:
         nir.Conv2d: lambda n: _nir_to_snntorch_module(n, init_hidden=True),
         nir.Flatten: lambda n: _nir_to_snntorch_module(n, init_hidden=True),
         nir.AvgPool2d: lambda n: _nir_to_snntorch_module(n, init_hidden=True),
+        nir.IF: lambda n: _nir_to_snntorch_module(n, init_hidden=True),
         nir.LIF: lambda n: _nir_to_snntorch_module(n, init_hidden=True),
         nir.CubaLIF: lambda n: _nir_to_snntorch_module(n, init_hidden=True),
     }


### PR DESCRIPTION
`nir.IF` import support got lost when we moved to the new `nirtorch.nir_to_torch` API in 92090df.

Readding support here.