### PR TITLE
bump NIR and NIRTorch version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -108,8 +108,8 @@ The following packages are automatically installed if using the pip command:
 
 The following packages are required for using `export_nir` and `import_nir`:
 
-* nir
-* nirtorch
+* nir>=1.0.6
+* nirtorch>=2.0.5
 
 The following packages are required for using `spikeplot`:
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,6 +6,6 @@ matplotlib
 celluloid
 numpy>=1.17
 tqdm
-nir
-nirtorch
+nir>=1.0.6
+nirtorch>=2.0.5
 sphinx_rtd_theme

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -11,6 +11,6 @@ pytest==6.2.5
 sphinx-rtd-theme
 pre-commit
 torch
-nir
-nirtorch
+nir>=1.0.6
+nirtorch>=2.0.5
 matplotlib


### PR DESCRIPTION
With the latest commits, we are no longer compatible with older NIR and NIRTorch versions.

snntorch doesn't have a direct dependency to those libraries (as in, they are not listed in pyproject.yaml),
so this just changes the version in tests and documentation.