### PR TITLE
nir: fix import of IF node

### DIFF
--- a/snntorch/import_nir.py
+++ b/snntorch/import_nir.py
@@ -232,9 +232,9 @@ def _nir_to_snntorch_module(
         r = np.unique(node.r)[0]
         assert r == 1, "r != 1 not supported"
         mod = snn.Leaky(
-            beta=0.9,
+            beta=0,
             threshold=vthr * r,
-            init_hidden=False,
+            init_hidden=init_hidden,
             reset_delay=False,
         )
         return mod


### PR DESCRIPTION
* init_hidden should be set to the global init_hidden parameter, similar to LIF
* IF does not have a decay, so beta should be zero