### PR TITLE
Fix reset calculation in forward function

### DIFF
--- a/docs/tutorials/tutorial_6.rst
+++ b/docs/tutorials/tutorial_6.rst
@@ -142,7 +142,7 @@ the gradient of the fast sigmoid function can override the Dirac-Delta function 
       # the forward function is called each time we call Leaky
       def forward(self, input_, mem):
         spk = self.surrogate_func((mem-self.threshold))  # call the Heaviside function
-        reset = (spk - self.threshold).detach()
+        reset = (spk * self.threshold).detach()
         mem = self.beta * mem + input_ - reset
         return spk, mem
     

--- a/docs/tutorials/zh-cn/tutorial_5_cn.rst
+++ b/docs/tutorials/zh-cn/tutorial_5_cn.rst
@@ -210,7 +210,7 @@ snnTorch 的默认方法（截至 v0.6.0）是用反正切函数平滑 Heaviside
     
           @staticmethod
           def backward(ctx, grad_output):
-              (spk,) = ctx.saved_tensors  # retrieve the membrane potential 
+              (mem,) = ctx.saved_tensors  # retrieve the membrane potential 
               grad = 1 / (1 + (np.pi * mem).pow_(2)) * grad_output # Eqn 5
               return grad
 

--- a/docs/tutorials/zh-cn/tutorial_6_cn.rst
+++ b/docs/tutorials/zh-cn/tutorial_6_cn.rst
@@ -128,7 +128,7 @@ snnTorch 教程系列基于以下论文。如果您发现这些资源或代码�
       # forward 函数在每次调用 Leaky 时被调用
       def forward(self, input_, mem):
         spk = self.surrogate_func((mem-self.threshold))  # 调用 Heaviside 函数
-        reset = (spk - self.threshold).detach()
+        reset = (spk * self.threshold).detach()
         mem = self.beta * mem + input_ - reset
         return spk, mem
     


### PR DESCRIPTION
Hi, I found an issue in tutorial 6.
```
  def forward(self, input_, mem):
    spk = self.surrogate_func((mem-self.threshold))  # call the Heaviside function
    reset = (spk - self.threshold).detach()
    mem = self.beta * mem + input_ - reset
    return spk, mem
```
The reset computation is incorrect, and it should be `reset = (spk * self.threshold).detach()`.