### PR TITLE
fix: correct LSO surrogate, add missing @staticmethod, fix __layer__ string concat

### DIFF
--- a/snntorch/_layers/__init__.py
+++ b/snntorch/_layers/__init__.py
@@ -1,4 +1,4 @@
-__layer__ = ["BatchNormTT1d", "BatchNormTT2d" "GradedSpikes"]
+__layer__ = ["BatchNormTT1d", "BatchNormTT2d", "GradedSpikes"]
 
 from .bntt import *
 from .graded_spikes import *

--- a/snntorch/surrogate.py
+++ b/snntorch/surrogate.py
@@ -358,6 +358,7 @@ class SpikeRateEscape(torch.autograd.Function):
         out = (input_ > 0).float()
         return out
 
+    @staticmethod
     def backward(ctx, grad_output):
         (input_,) = ctx.saved_tensors
         grad_input = grad_output.clone()
@@ -512,7 +513,7 @@ def LSO(slope=0.1):
     slope = slope
 
     def inner(x):
-        return StochasticSpikeOperator.apply(x, slope)
+        return LeakySpikeOperator.apply(x, slope)
 
     return inner
 


### PR DESCRIPTION
## Summary

- **Fix `LSO()` surrogate function** (issue #347): was calling `StochasticSpikeOperator.apply(x, slope)` instead of `LeakySpikeOperator.apply(x, slope)`. `StochasticSpikeOperator` expects 3 arguments (input, mean, variance) but `LSO` only passes 2 (input, slope), causing a `TypeError` at runtime.

- **Add missing `@staticmethod`** to `SpikeRateEscape.backward` in `surrogate.py`. The `forward` method at line ~353 correctly has `@staticmethod`, but `backward` at line ~361 is missing it. Without it, PyTorch autograd will pass `self` as the first argument instead of the context object.

- **Add missing comma** between `"BatchNormTT2d"` and `"GradedSpikes"` in `_layers/__init__.py`. Adjacent string literals without a comma causes Python to concatenate them into `"BatchNormTT2dGradedSpikes"`.

## Test plan

- [ ] `LSO()` now correctly dispatches to `LeakySpikeOperator` which accepts (input, slope)
- [ ] `SpikeRateEscape.backward` now matches PyTorch's `torch.autograd.Function` convention
- [ ] `__layer__` list now correctly contains 3 separate strings