### PR TITLE
Add Optuna hyperparameter optimization tutorial

### DIFF
--- a/docs/tutorials/tutorial_optuna.rst
+++ b/docs/tutorials/tutorial_optuna.rst
@@ -1,0 +1,553 @@
+===================================================
+Hyperparameter Optimization with Optuna
+===================================================
+
+Tutorial written by Reto Stamm
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. image:: https://colab.research.google.com/assets/colab-badge.svg
+        :alt: Open In Colab
+        :target: https://colab.research.google.com/github/jeshraghian/snntorch/blob/master/examples/tutorial_optuna.ipynb
+
+The snnTorch tutorial series is based on the following paper. If you find these resources or code useful in your work, please consider citing the following source:
+
+    `Jason K. Eshraghian, Max Ward, Emre Neftci, Xinxin Wang, Gregor Lenz, Girish
+    Dwivedi, Mohammed Bennamoun, Doo Seok Jeong, and Wei D. Lu. "Training
+    Spiking Neural Networks Using Lessons From Deep Learning". Proceedings of the IEEE, 111(9) September 2023. <https://ieeexplore.ieee.org/abstract/document/10242251>`_
+
+.. note::
+  This tutorial is a static non-editable version. Interactive, editable versions are available via the following links:
+    * `Google Colab <https://colab.research.google.com/github/jeshraghian/snntorch/blob/master/examples/tutorial_optuna.ipynb>`_
+    * `Local Notebook (download via GitHub) <https://github.com/jeshraghian/snntorch/tree/master/examples>`_
+
+
+Introduction
+============
+
+This tutorial demonstrates how to optimize Spiking Neural Network
+hyperparameters with `Optuna <https://optuna.org>`_, an efficient
+open-source hyperparameter optimization framework.
+
+We frame the problem as a **multi-objective optimization**: maximize
+classification accuracy while minimizing spike count (a proxy for power
+consumption). Optuna explores network architecture (depth, width),
+temporal parameters (timesteps), and training settings (learning rate,
+decay) to find Pareto-optimal configurations.
+
+For a comprehensive overview of SNNs and snnTorch, see the
+`snnTorch tutorial series <https://snntorch.readthedocs.io/en/latest/tutorials/index.html>`_.
+
+::
+
+    !pip install optuna snntorch
+
+.. code:: python
+
+    import logging
+    import time
+
+    import matplotlib.pyplot as plt
+    import optuna
+    from optuna.exceptions import TrialPruned
+    from optuna.trial import TrialState
+    import optuna.visualization.matplotlib as optuna_plt
+
+    import torch
+    import torch.nn as nn
+    from torch.utils.data import DataLoader, Subset
+
+    import torchvision.datasets as datasets
+    import torchvision.transforms as transforms
+
+    import snntorch as snn
+    import snntorch.functional as SF
+
+
+1. The MNIST Dataset
+====================
+
+1.1 Dataloading
+~~~~~~~~~~~~~~~
+
+Define variables for dataloading.
+
+.. code:: python
+
+    batch_size = 128
+    data_path = '/tmp/data/mnist'
+
+Load the dataset. We split out a validation set for hyperparameter
+evaluation. The test set is never used during tuning to avoid data
+leakage.
+
+The split is deterministic (fixed index ranges) so that results are
+reproducible across runs.
+
+.. code:: python
+
+    transform = transforms.Compose([
+        transforms.Resize((28, 28)),
+        transforms.Grayscale(),
+        transforms.ToTensor(),
+        transforms.Normalize((0,), (1,)),
+    ])
+
+    mnist_train = datasets.MNIST(data_path, train=True, download=True, transform=transform)
+
+    # Deterministic train/validation split (92%/8%)
+    total_size = len(mnist_train)
+    val_size = int(total_size * 0.08)
+    train_size = total_size - val_size
+
+    mnist_val = Subset(mnist_train, range(train_size, total_size))
+    mnist_train = Subset(mnist_train, range(0, train_size))
+
+    mnist_test = datasets.MNIST(data_path, train=False, download=True, transform=transform)
+
+    train_loader = DataLoader(mnist_train, batch_size=batch_size, shuffle=True)
+    validation_loader = DataLoader(mnist_val, batch_size=batch_size, shuffle=True)
+    test_loader = DataLoader(mnist_test, batch_size=batch_size, shuffle=True)
+
+.. code:: python
+
+    device = (
+        "cuda" if torch.cuda.is_available()
+        else "mps" if torch.backends.mps.is_available()
+        else "cpu"
+    )
+    print(f"Running on {device}")
+
+    logger = logging.getLogger("optuna")
+
+
+2. A Parameterizable Network
+=============================
+
+The network has several fixed aspects:
+
+- **Input**: 28x28 = 784 pixels
+- **Output**: 10 neurons (digits 0-9)
+
+Everything else is a tunable hyperparameter:
+
+- Number of hidden layers and neurons per layer
+- Number of timesteps
+- First-layer decay rate (beta1); all other layers learn their own beta
+
+We also track total spike activity across the network to estimate power
+consumption.
+
+.. code:: python
+
+    class Net(nn.Module):
+
+        def __init__(self, num_steps, num_hidden_neurons=299, num_hidden_layers=1, beta1=0.9):
+            super().__init__()
+            assert 0 <= beta1 <= 1, "Beta1 must be between 0 and 1"
+            assert num_hidden_layers >= 0, "Number of hidden layers must be non-negative"
+
+            num_inputs = 28 * 28
+            num_outputs = 10
+            self.num_steps = num_steps
+            self.num_hidden_neurons = num_hidden_neurons
+            self.num_hidden_layers = num_hidden_layers
+
+            self.layers = []
+            for n in range(num_hidden_layers + 1):
+                layer = {}
+                if n == 0:
+                    layer['fc'] = nn.Linear(num_inputs, num_hidden_neurons)
+                    layer['lif'] = snn.Leaky(beta=beta1)
+                elif n < num_hidden_layers:
+                    layer['fc'] = nn.Linear(num_hidden_neurons, num_hidden_neurons)
+                    beta2 = torch.rand(num_hidden_neurons, dtype=torch.float)
+                    layer['lif'] = snn.Leaky(beta=beta2, learn_beta=True)
+                else:
+                    layer['fc'] = nn.Linear(num_hidden_neurons, num_outputs)
+                    beta2 = torch.rand(num_outputs, dtype=torch.float)
+                    layer['lif'] = snn.Leaky(beta=beta2, learn_beta=True)
+
+                self.add_module(f'fc{n}', layer['fc'])
+                self.add_module(f'lif{n}', layer['lif'])
+                self.layers.append(layer)
+
+            self.reset_spikes()
+
+        def forward(self, x):
+            for layer in self.layers:
+                layer['mem'] = layer['lif'].init_leaky()
+
+            spk_rec, mem_rec = [], []
+
+            for step in range(self.num_steps):
+                cur = x.flatten(1)
+                for layer in self.layers:
+                    cur, layer['mem'] = layer['lif'](layer['fc'](cur), layer['mem'])
+                    self.total_spike_count += cur.sum().item()
+                spk_rec.append(cur)
+                mem_rec.append(self.layers[-1]['mem'])
+
+            self.forward_count += 1
+            return torch.stack(spk_rec), torch.stack(mem_rec)
+
+        def get_spikes_per_digit(self):
+            return self.total_spike_count / self.forward_count
+
+        def reset_spikes(self):
+            self.total_spike_count = 0
+            self.forward_count = 0
+
+
+3. The Trainer
+==============
+
+The trainer wraps the training loop with **early stopping**. Because
+Optuna evaluates networks of wildly different sizes, we adapt the
+stopping criterion to the network depth:
+
+.. math:: \text{significance}_{\text{actual}} = \frac{\text{significance}_{\text{base}}}{\text{layers}^3}
+
+A single-layer network stops if loss hasn't improved by 5% in the last
+300 batches. A 10-layer network accepts nearly any improvement -- deep
+networks train more slowly and make smaller per-batch gains.
+
+This heuristic prevents both overtraining shallow networks and
+prematurely killing deep ones.
+
+.. code:: python
+
+    class SNNTrainer:
+
+        def __init__(self, net, trial, num_epochs=30, num_steps=25,
+                     learning_rate=2e-3, patience=300, sig_improvement=0.05):
+            self.net = net.to(device)
+            self.num_epochs = num_epochs
+            self.num_steps = num_steps
+            self.learning_rate = learning_rate
+            self.trial = trial
+            self.patience = patience
+            self.sig_improvement = sig_improvement / (net.num_hidden_layers ** 3)
+
+            self.optimizer = torch.optim.Adam(
+                self.net.parameters(), lr=learning_rate, betas=(0.9, 0.999)
+            )
+            self.loss_fn = SF.mse_count_loss(correct_rate=0.8, incorrect_rate=0.2)
+            self.loss_hist = []
+            self.acc_hist = []
+            self.epochs = 0
+            self.batches = 0
+
+        def train(self, train_loader):
+            best_loss = float("inf")
+            loss_counter = 0
+
+            for epoch in range(self.num_epochs):
+                for i, (data, targets) in enumerate(train_loader):
+                    data = data.to(device)
+                    targets = targets.to(device)
+
+                    self.net.train()
+                    spk_rec, _ = self.net(data)
+                    loss_val = self.loss_fn(spk_rec, targets)
+                    self.optimizer.zero_grad()
+                    loss_val.backward()
+                    self.optimizer.step()
+
+                    current_loss = loss_val.item()
+                    self.loss_hist.append(current_loss)
+
+                    if i % 100 == 0 and i != 0:
+                        acc = SF.accuracy_rate(spk_rec, targets)
+                        self.acc_hist.append(acc)
+                        logger.info(
+                            f"Trial {self.trial.number}: Epoch {epoch}, Batch {i} "
+                            f"Loss: {current_loss:.4f} (best: {best_loss:.4f} t-{loss_counter}) "
+                            f"Acc: {acc * 100:.2f}%"
+                        )
+
+                    if current_loss < (1 - self.sig_improvement) * best_loss:
+                        best_loss = current_loss
+                        loss_counter = 0
+                    else:
+                        loss_counter += 1
+
+                    self.batches += 1
+
+                    if epoch > 0 and loss_counter > self.patience:
+                        logger.info("Early stopping.")
+                        return
+
+                self.epochs += 1
+
+        def get_accuracy(self, data_loader):
+            total_acc = 0
+            total = 0
+            with torch.no_grad():
+                self.net.eval()
+                for data, targets in data_loader:
+                    data = data.to(device)
+                    targets = targets.to(device)
+                    spk_rec, _ = self.net(data)
+                    acc = SF.accuracy_rate(spk_rec, targets)
+                    total_acc += acc * data.size(0)
+                    total += data.size(0)
+            return total_acc / total
+
+
+4. The Objective
+================
+
+We have two targets:
+
+- **Maximize** validation accuracy
+- **Minimize** spikes per digit (proxy for power consumption)
+
+Optuna explores five hyperparameters within bounded ranges. Networks
+that are too computationally expensive (large x deep x many timesteps)
+are pruned before training starts.
+
+.. code:: python
+
+    def optuna_objective(trial, train_loader, validation_loader):
+        num_steps = trial.suggest_int('Timesteps', 10, 50)
+        num_hidden_layers = trial.suggest_int('Hidden Layers', 1, 10)
+        num_hidden_neurons = trial.suggest_int('Neurons per Hidden Layer', 5, 300)
+        learning_rate = trial.suggest_float('Learning Rate', 1e-4, 1e-2, log=True)
+        first_layer_beta = trial.suggest_float('First Layer Beta', 0.5, 1)
+
+        logger.info(
+            f"Trial {trial.number}: Layers={num_hidden_layers} "
+            f"Neurons={num_hidden_neurons} Steps={num_steps} "
+            f"Beta1={first_layer_beta:.2f}"
+        )
+
+        # Prune configurations that would take too long
+        if num_hidden_layers * num_hidden_neurons * num_steps > 300 * 15:
+            raise TrialPruned("Too computationally intensive.")
+
+        net = Net(num_steps, num_hidden_neurons, num_hidden_layers, first_layer_beta)
+
+        trainer = SNNTrainer(net, trial, num_steps=num_steps, learning_rate=learning_rate)
+        training_start_time = time.time()
+        trainer.train(train_loader)
+
+        trial.set_user_attr("Training Time [s]", time.time() - training_start_time)
+        trial.set_user_attr("Epochs", trainer.epochs)
+        trial.set_user_attr("Batches", trainer.batches)
+
+        net.reset_spikes()
+        validation_accuracy = trainer.get_accuracy(validation_loader)
+        spikes_per_digit = net.get_spikes_per_digit()
+
+        return validation_accuracy, spikes_per_digit
+
+
+    objective_names = ["Validation Accuracy", "Spikes per Digit"]
+    objective_directions = ["maximize", "minimize"]
+
+
+5. Run the Study
+================
+
+We run 10 trials by default. This is enough to see clear trends on a
+free Colab GPU (typically 10-30 minutes). Increase ``n_trials`` for a
+more thorough search.
+
+.. code:: python
+
+    study = optuna.create_study(
+        study_name="Minimize spikes, maximize accuracy",
+        directions=objective_directions,
+    )
+
+    n_trials = 10  # increase for a more thorough search
+
+    start_time = time.time()
+
+    study.optimize(
+        lambda trial: optuna_objective(trial, train_loader, validation_loader),
+        n_trials=n_trials,
+    )
+
+    n_complete = sum(1 for t in study.trials if t.state == TrialState.COMPLETE)
+    elapsed = time.time() - start_time
+    print(f"\nDone: {n_complete} completed trials in {elapsed / 60:.1f} minutes")
+
+
+6. Analyze the Results
+======================
+
+6.1 Helper: scatter plot
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+This utility plots any two metrics on the axes with a third as color,
+making it easy to explore three-way relationships between
+hyperparameters and objectives.
+
+.. code:: python
+
+    def plot_study(study, x_name, y_name, z_name,
+                   y_range=None, z_clip=None):
+        """Scatter plot of completed trials: x vs y, colored by z."""
+        trials = [t for t in study.trials if t.state == TrialState.COMPLETE]
+
+        def _val(trial, name):
+            if name in objective_names:
+                return trial.values[objective_names.index(name)]
+            return trial.params.get(name)
+
+        xs, ys, zs = [], [], []
+        for t in trials:
+            x, y, z = _val(t, x_name), _val(t, y_name), _val(t, z_name)
+            if None in (x, y, z):
+                continue
+            if z_clip and not (z_clip[0] <= z <= z_clip[1]):
+                continue
+            if y_range and not (y_range[0] <= y <= y_range[1]):
+                continue
+            xs.append(x); ys.append(y); zs.append(z)
+
+        fig, ax = plt.subplots(figsize=(8, 5))
+        sc = ax.scatter(xs, ys, c=zs, cmap='viridis', alpha=0.7,
+                        edgecolors='k', linewidth=0.5)
+        plt.colorbar(sc, label=z_name)
+        ax.set_xlabel(x_name)
+        ax.set_ylabel(y_name)
+        ax.set_title(f"{z_name} by {x_name} vs {y_name}")
+        if y_range:
+            ax.set_ylim(y_range)
+        plt.tight_layout()
+        plt.show()
+
+
+6.2 Pareto Front
+~~~~~~~~~~~~~~~~
+
+The Pareto front shows the best trade-offs between accuracy and spike
+count. Points on the front cannot be improved in one objective without
+worsening the other.
+
+.. code:: python
+
+    optuna_plt.plot_pareto_front(
+        study,
+        target_names=objective_names,
+    )
+    plt.tight_layout()
+    plt.show()
+
+
+6.3 Accuracy vs Spikes
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Each dot is a trained network. We want to be in the **top-left** corner
+(high accuracy, few spikes). The color shows the number of hidden
+layers.
+
+.. code:: python
+
+    plot_study(study, "Spikes per Digit", "Validation Accuracy", "Hidden Layers")
+
+Let's zoom in to accuracies above 60%:
+
+.. code:: python
+
+    plot_study(study, "Spikes per Digit", "Validation Accuracy", "Hidden Layers",
+               y_range=(0.60, 1), z_clip=(1, 5))
+
+
+6.4 Network Size vs Accuracy
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+How does the number of neurons and layers affect accuracy?
+
+.. code:: python
+
+    plot_study(study, "Neurons per Hidden Layer", "Hidden Layers",
+               "Validation Accuracy", z_clip=(0.8, 1))
+
+Note the empty top-right corner -- those configurations were pruned as
+too expensive. The most accurate networks tend to have 100-200 neurons
+on 1-2 layers.
+
+Now the same axes, but colored by spike count:
+
+.. code:: python
+
+    plot_study(study, "Neurons per Hidden Layer", "Hidden Layers",
+               "Spikes per Digit", z_clip=(20000, 80000))
+
+Larger networks produce far more spikes and are less power-efficient.
+
+
+6.5 Other Hyperparameters
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code:: python
+
+    plot_study(study, "First Layer Beta", "Validation Accuracy",
+               "Spikes per Digit", z_clip=(30000, 80000), y_range=(0.8, 1))
+
+All values of beta can yield high accuracy, but values close to 1 seem
+to correlate with lower spike counts.
+
+.. code:: python
+
+    plot_study(study, "Timesteps", "Validation Accuracy",
+               "Spikes per Digit", z_clip=(30000, 80000), y_range=(0.8, 1))
+
+More timesteps means more spikes. The sweet spot appears to be around
+15-20 timesteps.
+
+.. code:: python
+
+    plot_study(study, "Learning Rate", "Validation Accuracy",
+               "Spikes per Digit", z_clip=(30000, 80000), y_range=(0.8, 1))
+
+The log-scale sampling concentrates trials at lower learning rates. The
+high end of the range may be worth exploring further.
+
+
+6.6 Hyperparameter Importance
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Optuna can estimate which hyperparameters have the most influence on
+each objective.
+
+.. code:: python
+
+    optuna_plt.plot_param_importances(
+        study,
+        target=lambda t: t.values[0],
+        target_name="Validation Accuracy",
+    )
+    plt.tight_layout()
+    plt.show()
+
+.. code:: python
+
+    optuna_plt.plot_param_importances(
+        study,
+        target=lambda t: t.values[1],
+        target_name="Spikes per Digit",
+    )
+    plt.tight_layout()
+    plt.show()
+
+The bar length indicates how much each hyperparameter affects the
+objective -- it does not indicate whether the value should be large or
+small.
+
+
+6.7 Summary
+~~~~~~~~~~~~
+
+From the data, the optimal SNN for this task is likely:
+
+- **1-2 hidden layers**
+- **100-200 neurons per layer**
+- **15-20 timesteps**
+- **First-layer beta >= 0.9**
+
+This drastically reduces the search space. A follow-up study could
+focus on this region with more trials for finer resolution.

--- a/docs/tutorials/tutorials.rst
+++ b/docs/tutorials/tutorials.rst
@@ -89,6 +89,11 @@ The tutorial consists of a series of Google Colab notebooks. Static non-editable
         :alt: Open In Colab
         :target: https://colab.research.google.com/github/jeshraghian/snntorch/blob/master/examples/tutorial_forward_forward.ipynb
 
+   * - `Hyperparameter Optimization with Optuna <https://snntorch.readthedocs.io/en/latest/tutorials/tutorial_optuna.html>`_
+     - .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        :alt: Open In Colab
+        :target: https://colab.research.google.com/github/jeshraghian/snntorch/blob/master/examples/tutorial_optuna.ipynb
+
 
 .. list-table::
    :widths: 70 32

--- a/examples/tutorial_optuna.ipynb
+++ b/examples/tutorial_optuna.ipynb
@@ -1,0 +1,696 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://github.com/jeshraghian/snntorch/\">\n",
+    "<img src=\"https://github.com/jeshraghian/snntorch/blob/master/docs/_static/img/snntorch_alpha_w.png?raw=true\" width=\"300\">\n",
+    "</a>\n",
+    "\n",
+    "# Hyperparameter Optimization with Optuna\n",
+    "### Tutorial written by Reto Stamm\n",
+    "\n",
+    "<a href=\"https://colab.research.google.com/github/jeshraghian/snntorch/blob/master/examples/tutorial_optuna.ipynb\">\n",
+    "  <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
+    "</a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This tutorial demonstrates how to optimize Spiking Neural Network hyperparameters with [Optuna](https://optuna.org), an efficient open-source hyperparameter optimization framework.\n",
+    "\n",
+    "We frame the problem as a **multi-objective optimization**: maximize classification accuracy while minimizing spike count (a proxy for power consumption). Optuna explores network architecture (depth, width), temporal parameters (timesteps), and training settings (learning rate, decay) to find Pareto-optimal configurations.\n",
+    "\n",
+    "For a comprehensive overview of SNNs and snnTorch, see the [snnTorch tutorial series](https://snntorch.readthedocs.io/en/latest/tutorials/index.html)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The snnTorch tutorial series is based on the following paper. If you find these resources or code useful in your work, please consider citing the following source:\n",
+    "\n",
+    "> [Jason K. Eshraghian, Max Ward, Emre Neftci, Xinxin Wang, Gregor Lenz, Girish Dwivedi, Mohammed Bennamoun, Doo Seok Jeong, and Wei D. Lu. \"Training Spiking Neural Networks Using Lessons From Deep Learning\". Proceedings of the IEEE, 111(9) September 2023.](https://ieeexplore.ieee.org/abstract/document/10242251)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install optuna snntorch --quiet"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "import time\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import optuna\n",
+    "from optuna.exceptions import TrialPruned\n",
+    "from optuna.trial import TrialState\n",
+    "import optuna.visualization.matplotlib as optuna_plt\n",
+    "\n",
+    "import torch\n",
+    "import torch.nn as nn\n",
+    "from torch.utils.data import DataLoader, Subset\n",
+    "\n",
+    "import torchvision.datasets as datasets\n",
+    "import torchvision.transforms as transforms\n",
+    "\n",
+    "import snntorch as snn\n",
+    "import snntorch.functional as SF"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. The MNIST Dataset\n",
+    "\n",
+    "### 1.1 Dataloading\n",
+    "\n",
+    "Define variables for dataloading."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "batch_size = 128\n",
+    "data_path = '/tmp/data/mnist'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Load the dataset. We split out a validation set for hyperparameter evaluation. The test set is never used during tuning to avoid data leakage.\n",
+    "\n",
+    "The split is deterministic (fixed index ranges) so that results are reproducible across runs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "transform = transforms.Compose([\n",
+    "    transforms.Resize((28, 28)),\n",
+    "    transforms.Grayscale(),\n",
+    "    transforms.ToTensor(),\n",
+    "    transforms.Normalize((0,), (1,)),\n",
+    "])\n",
+    "\n",
+    "mnist_train = datasets.MNIST(data_path, train=True, download=True, transform=transform)\n",
+    "\n",
+    "# Deterministic train/validation split (92%/8%)\n",
+    "total_size = len(mnist_train)\n",
+    "val_size = int(total_size * 0.08)\n",
+    "train_size = total_size - val_size\n",
+    "\n",
+    "mnist_val = Subset(mnist_train, range(train_size, total_size))\n",
+    "mnist_train = Subset(mnist_train, range(0, train_size))\n",
+    "\n",
+    "mnist_test = datasets.MNIST(data_path, train=False, download=True, transform=transform)\n",
+    "\n",
+    "train_loader = DataLoader(mnist_train, batch_size=batch_size, shuffle=True)\n",
+    "validation_loader = DataLoader(mnist_val, batch_size=batch_size, shuffle=True)\n",
+    "test_loader = DataLoader(mnist_test, batch_size=batch_size, shuffle=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "device = (\n",
+    "    \"cuda\" if torch.cuda.is_available()\n",
+    "    else \"mps\" if torch.backends.mps.is_available()\n",
+    "    else \"cpu\"\n",
+    ")\n",
+    "print(f\"Running on {device}\")\n",
+    "\n",
+    "logger = logging.getLogger(\"optuna\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. A Parameterizable Network\n",
+    "\n",
+    "The network has several fixed aspects:\n",
+    "- **Input**: 28\u00d728 = 784 pixels\n",
+    "- **Output**: 10 neurons (digits 0\u20139)\n",
+    "\n",
+    "Everything else is a tunable hyperparameter:\n",
+    "- Number of hidden layers and neurons per layer\n",
+    "- Number of timesteps\n",
+    "- First-layer decay rate (\u03b2\u2081); all other layers learn their own \u03b2\n",
+    "\n",
+    "We also track total spike activity across the network to estimate power consumption."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class Net(nn.Module):\n",
+    "\n",
+    "    def __init__(self, num_steps, num_hidden_neurons=299, num_hidden_layers=1, beta1=0.9):\n",
+    "        super().__init__()\n",
+    "        assert 0 <= beta1 <= 1, \"Beta1 must be between 0 and 1\"\n",
+    "        assert num_hidden_layers >= 0, \"Number of hidden layers must be non-negative\"\n",
+    "\n",
+    "        num_inputs = 28 * 28\n",
+    "        num_outputs = 10\n",
+    "        self.num_steps = num_steps\n",
+    "        self.num_hidden_neurons = num_hidden_neurons\n",
+    "        self.num_hidden_layers = num_hidden_layers\n",
+    "\n",
+    "        self.layers = []\n",
+    "        for n in range(num_hidden_layers + 1):\n",
+    "            layer = {}\n",
+    "            if n == 0:\n",
+    "                layer['fc'] = nn.Linear(num_inputs, num_hidden_neurons)\n",
+    "                layer['lif'] = snn.Leaky(beta=beta1)\n",
+    "            elif n < num_hidden_layers:\n",
+    "                layer['fc'] = nn.Linear(num_hidden_neurons, num_hidden_neurons)\n",
+    "                beta2 = torch.rand(num_hidden_neurons, dtype=torch.float)\n",
+    "                layer['lif'] = snn.Leaky(beta=beta2, learn_beta=True)\n",
+    "            else:\n",
+    "                layer['fc'] = nn.Linear(num_hidden_neurons, num_outputs)\n",
+    "                beta2 = torch.rand(num_outputs, dtype=torch.float)\n",
+    "                layer['lif'] = snn.Leaky(beta=beta2, learn_beta=True)\n",
+    "\n",
+    "            self.add_module(f'fc{n}', layer['fc'])\n",
+    "            self.add_module(f'lif{n}', layer['lif'])\n",
+    "            self.layers.append(layer)\n",
+    "\n",
+    "        self.reset_spikes()\n",
+    "\n",
+    "    def forward(self, x):\n",
+    "        for layer in self.layers:\n",
+    "            layer['mem'] = layer['lif'].init_leaky()\n",
+    "\n",
+    "        spk_rec, mem_rec = [], []\n",
+    "\n",
+    "        for step in range(self.num_steps):\n",
+    "            cur = x.flatten(1)\n",
+    "            for layer in self.layers:\n",
+    "                cur, layer['mem'] = layer['lif'](layer['fc'](cur), layer['mem'])\n",
+    "                self.total_spike_count += cur.sum().item()\n",
+    "            spk_rec.append(cur)\n",
+    "            mem_rec.append(self.layers[-1]['mem'])\n",
+    "\n",
+    "        self.forward_count += 1\n",
+    "        return torch.stack(spk_rec), torch.stack(mem_rec)\n",
+    "\n",
+    "    def get_spikes_per_digit(self):\n",
+    "        return self.total_spike_count / self.forward_count\n",
+    "\n",
+    "    def reset_spikes(self):\n",
+    "        self.total_spike_count = 0\n",
+    "        self.forward_count = 0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. The Trainer\n",
+    "\n",
+    "The trainer wraps the training loop with **early stopping**. Because Optuna evaluates networks of wildly different sizes, we adapt the stopping criterion to the network depth:\n",
+    "\n",
+    "$$\\text{significance}_{\\text{actual}} = \\frac{\\text{significance}_{\\text{base}}}{\\text{layers}^3}$$\n",
+    "\n",
+    "A single-layer network stops if loss hasn't improved by 5% in the last 300 batches. A 10-layer network accepts nearly any improvement\u2014deep networks train more slowly and make smaller per-batch gains.\n",
+    "\n",
+    "This heuristic prevents both overtraining shallow networks and prematurely killing deep ones."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class SNNTrainer:\n",
+    "\n",
+    "    def __init__(self, net, trial, num_epochs=30, num_steps=25,\n",
+    "                 learning_rate=2e-3, patience=300, sig_improvement=0.05):\n",
+    "        self.net = net.to(device)\n",
+    "        self.num_epochs = num_epochs\n",
+    "        self.num_steps = num_steps\n",
+    "        self.learning_rate = learning_rate\n",
+    "        self.trial = trial\n",
+    "        self.patience = patience\n",
+    "        self.sig_improvement = sig_improvement / (net.num_hidden_layers ** 3)\n",
+    "\n",
+    "        self.optimizer = torch.optim.Adam(\n",
+    "            self.net.parameters(), lr=learning_rate, betas=(0.9, 0.999)\n",
+    "        )\n",
+    "        self.loss_fn = SF.mse_count_loss(correct_rate=0.8, incorrect_rate=0.2)\n",
+    "        self.loss_hist = []\n",
+    "        self.acc_hist = []\n",
+    "        self.epochs = 0\n",
+    "        self.batches = 0\n",
+    "\n",
+    "    def train(self, train_loader):\n",
+    "        best_loss = float(\"inf\")\n",
+    "        loss_counter = 0\n",
+    "\n",
+    "        for epoch in range(self.num_epochs):\n",
+    "            for i, (data, targets) in enumerate(train_loader):\n",
+    "                data = data.to(device)\n",
+    "                targets = targets.to(device)\n",
+    "\n",
+    "                self.net.train()\n",
+    "                spk_rec, _ = self.net(data)\n",
+    "                loss_val = self.loss_fn(spk_rec, targets)\n",
+    "                self.optimizer.zero_grad()\n",
+    "                loss_val.backward()\n",
+    "                self.optimizer.step()\n",
+    "\n",
+    "                current_loss = loss_val.item()\n",
+    "                self.loss_hist.append(current_loss)\n",
+    "\n",
+    "                if i % 100 == 0 and i != 0:\n",
+    "                    acc = SF.accuracy_rate(spk_rec, targets)\n",
+    "                    self.acc_hist.append(acc)\n",
+    "                    logger.info(\n",
+    "                        f\"Trial {self.trial.number}: Epoch {epoch}, Batch {i} \"\n",
+    "                        f\"Loss: {current_loss:.4f} (best: {best_loss:.4f} t-{loss_counter}) \"\n",
+    "                        f\"Acc: {acc * 100:.2f}%\"\n",
+    "                    )\n",
+    "\n",
+    "                if current_loss < (1 - self.sig_improvement) * best_loss:\n",
+    "                    best_loss = current_loss\n",
+    "                    loss_counter = 0\n",
+    "                else:\n",
+    "                    loss_counter += 1\n",
+    "\n",
+    "                self.batches += 1\n",
+    "\n",
+    "                if epoch > 0 and loss_counter > self.patience:\n",
+    "                    logger.info(\"Early stopping.\")\n",
+    "                    return\n",
+    "\n",
+    "            self.epochs += 1\n",
+    "\n",
+    "    def get_accuracy(self, data_loader):\n",
+    "        total_acc = 0\n",
+    "        total = 0\n",
+    "        with torch.no_grad():\n",
+    "            self.net.eval()\n",
+    "            for data, targets in data_loader:\n",
+    "                data = data.to(device)\n",
+    "                targets = targets.to(device)\n",
+    "                spk_rec, _ = self.net(data)\n",
+    "                acc = SF.accuracy_rate(spk_rec, targets)\n",
+    "                total_acc += acc * data.size(0)\n",
+    "                total += data.size(0)\n",
+    "        return total_acc / total"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. The Objective\n",
+    "\n",
+    "We have two targets:\n",
+    "- **Maximize** validation accuracy\n",
+    "- **Minimize** spikes per digit (proxy for power consumption)\n",
+    "\n",
+    "Optuna explores five hyperparameters within bounded ranges. Networks that are too computationally expensive (large \u00d7 deep \u00d7 many timesteps) are pruned before training starts."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def optuna_objective(trial, train_loader, validation_loader):\n",
+    "    num_steps = trial.suggest_int('Timesteps', 10, 50)\n",
+    "    num_hidden_layers = trial.suggest_int('Hidden Layers', 1, 10)\n",
+    "    num_hidden_neurons = trial.suggest_int('Neurons per Hidden Layer', 5, 300)\n",
+    "    learning_rate = trial.suggest_float('Learning Rate', 1e-4, 1e-2, log=True)\n",
+    "    first_layer_beta = trial.suggest_float('First Layer Beta', 0.5, 1)\n",
+    "\n",
+    "    logger.info(\n",
+    "        f\"Trial {trial.number}: Layers={num_hidden_layers} \"\n",
+    "        f\"Neurons={num_hidden_neurons} Steps={num_steps} \"\n",
+    "        f\"Beta1={first_layer_beta:.2f}\"\n",
+    "    )\n",
+    "\n",
+    "    # Prune configurations that would take too long\n",
+    "    if num_hidden_layers * num_hidden_neurons * num_steps > 300 * 15:\n",
+    "        raise TrialPruned(\"Too computationally intensive.\")\n",
+    "\n",
+    "    net = Net(num_steps, num_hidden_neurons, num_hidden_layers, first_layer_beta)\n",
+    "\n",
+    "    trainer = SNNTrainer(net, trial, num_steps=num_steps, learning_rate=learning_rate)\n",
+    "    training_start_time = time.time()\n",
+    "    trainer.train(train_loader)\n",
+    "\n",
+    "    trial.set_user_attr(\"Training Time [s]\", time.time() - training_start_time)\n",
+    "    trial.set_user_attr(\"Epochs\", trainer.epochs)\n",
+    "    trial.set_user_attr(\"Batches\", trainer.batches)\n",
+    "\n",
+    "    net.reset_spikes()\n",
+    "    validation_accuracy = trainer.get_accuracy(validation_loader)\n",
+    "    spikes_per_digit = net.get_spikes_per_digit()\n",
+    "\n",
+    "    return validation_accuracy, spikes_per_digit\n",
+    "\n",
+    "\n",
+    "objective_names = [\"Validation Accuracy\", \"Spikes per Digit\"]\n",
+    "objective_directions = [\"maximize\", \"minimize\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Run the Study\n",
+    "\n",
+    "We run 10 trials by default. This is enough to see clear trends on a free Colab GPU (typically 10\u201330 minutes). Increase `n_trials` for a more thorough search."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "study = optuna.create_study(\n",
+    "    study_name=\"Minimize spikes, maximize accuracy\",\n",
+    "    directions=objective_directions,\n",
+    ")\n",
+    "\n",
+    "n_trials = 10  # increase for a more thorough search\n",
+    "\n",
+    "start_time = time.time()\n",
+    "\n",
+    "study.optimize(\n",
+    "    lambda trial: optuna_objective(trial, train_loader, validation_loader),\n",
+    "    n_trials=n_trials,\n",
+    ")\n",
+    "\n",
+    "n_complete = sum(1 for t in study.trials if t.state == TrialState.COMPLETE)\n",
+    "elapsed = time.time() - start_time\n",
+    "print(f\"\\nDone: {n_complete} completed trials in {elapsed / 60:.1f} minutes\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Analyze the Results\n",
+    "\n",
+    "### 6.1 Helper: scatter plot with color-coded third dimension\n",
+    "\n",
+    "This utility plots any two metrics on the axes with a third as color, making it easy to explore three-way relationships between hyperparameters and objectives."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def plot_study(study, x_name, y_name, z_name,\n",
+    "               y_range=None, z_clip=None):\n",
+    "    \"\"\"Scatter plot of completed trials: x vs y, colored by z.\"\"\"\n",
+    "    trials = [t for t in study.trials if t.state == TrialState.COMPLETE]\n",
+    "\n",
+    "    def _val(trial, name):\n",
+    "        if name in objective_names:\n",
+    "            return trial.values[objective_names.index(name)]\n",
+    "        return trial.params.get(name)\n",
+    "\n",
+    "    xs, ys, zs = [], [], []\n",
+    "    for t in trials:\n",
+    "        x, y, z = _val(t, x_name), _val(t, y_name), _val(t, z_name)\n",
+    "        if None in (x, y, z):\n",
+    "            continue\n",
+    "        if z_clip and not (z_clip[0] <= z <= z_clip[1]):\n",
+    "            continue\n",
+    "        if y_range and not (y_range[0] <= y <= y_range[1]):\n",
+    "            continue\n",
+    "        xs.append(x); ys.append(y); zs.append(z)\n",
+    "\n",
+    "    fig, ax = plt.subplots(figsize=(8, 5))\n",
+    "    sc = ax.scatter(xs, ys, c=zs, cmap='viridis', alpha=0.7,\n",
+    "                    edgecolors='k', linewidth=0.5)\n",
+    "    plt.colorbar(sc, label=z_name)\n",
+    "    ax.set_xlabel(x_name)\n",
+    "    ax.set_ylabel(y_name)\n",
+    "    ax.set_title(f\"{z_name} by {x_name} vs {y_name}\")\n",
+    "    if y_range:\n",
+    "        ax.set_ylim(y_range)\n",
+    "    plt.tight_layout()\n",
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 6.2 Pareto Front\n",
+    "\n",
+    "The Pareto front shows the best trade-offs between accuracy and spike count. Points on the front cannot be improved in one objective without worsening the other."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "optuna_plt.plot_pareto_front(\n",
+    "    study,\n",
+    "    target_names=objective_names,\n",
+    ")\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 6.3 Accuracy vs Spikes, colored by Hidden Layers\n",
+    "\n",
+    "Each dot is a trained network. We want to be in the **top-left** corner (high accuracy, few spikes). The color shows the number of hidden layers."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_study(study, \"Spikes per Digit\", \"Validation Accuracy\", \"Hidden Layers\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's zoom in to accuracies above 60%:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_study(study, \"Spikes per Digit\", \"Validation Accuracy\", \"Hidden Layers\",\n",
+    "           y_range=(0.60, 1), z_clip=(1, 5))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 6.4 Network Size vs Accuracy\n",
+    "\n",
+    "How does the number of neurons and layers affect accuracy?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_study(study, \"Neurons per Hidden Layer\", \"Hidden Layers\",\n",
+    "           \"Validation Accuracy\", z_clip=(0.8, 1))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note the empty top-right corner\u2014those configurations were pruned as too expensive. The most accurate networks tend to have 100\u2013200 neurons on 1\u20132 layers.\n",
+    "\n",
+    "Now the same axes, but colored by spike count:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_study(study, \"Neurons per Hidden Layer\", \"Hidden Layers\",\n",
+    "           \"Spikes per Digit\", z_clip=(20000, 80000))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Larger networks produce far more spikes and are less power-efficient.\n",
+    "\n",
+    "### 6.5 Other Hyperparameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_study(study, \"First Layer Beta\", \"Validation Accuracy\",\n",
+    "           \"Spikes per Digit\", z_clip=(30000, 80000), y_range=(0.8, 1))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "All values of \u03b2 can yield high accuracy, but values close to 1 seem to correlate with lower spike counts."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_study(study, \"Timesteps\", \"Validation Accuracy\",\n",
+    "           \"Spikes per Digit\", z_clip=(30000, 80000), y_range=(0.8, 1))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "More timesteps means more spikes. The sweet spot appears to be around 15\u201320 timesteps."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_study(study, \"Learning Rate\", \"Validation Accuracy\",\n",
+    "           \"Spikes per Digit\", z_clip=(30000, 80000), y_range=(0.8, 1))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The log-scale sampling concentrates trials at lower learning rates. The high end of the range may be worth exploring further.\n",
+    "\n",
+    "### 6.6 Hyperparameter Importance\n",
+    "\n",
+    "Optuna can estimate which hyperparameters have the most influence on each objective."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "optuna_plt.plot_param_importances(\n",
+    "    study,\n",
+    "    target=lambda t: t.values[0],\n",
+    "    target_name=\"Validation Accuracy\",\n",
+    ")\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "optuna_plt.plot_param_importances(\n",
+    "    study,\n",
+    "    target=lambda t: t.values[1],\n",
+    "    target_name=\"Spikes per Digit\",\n",
+    ")\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The bar length indicates how much each hyperparameter affects the objective\u2014it does not indicate whether the value should be large or small.\n",
+    "\n",
+    "### 6.7 Summary\n",
+    "\n",
+    "From the data, the optimal SNN for this task is likely:\n",
+    "\n",
+    "- **1\u20132 hidden layers**\n",
+    "- **100\u2013200 neurons per layer**\n",
+    "- **15\u201320 timesteps**\n",
+    "- **First-layer \u03b2 \u2265 0.9**\n",
+    "\n",
+    "This drastically reduces the search space. A follow-up study could focus on this region with more trials for finer resolution."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Multi-objective optimization (accuracy vs spike count) for SNNs using Optuna.

This is a revised version of #270, addressing the feedback:

- **Reduced default trials** from 50 to 10 — runs in ~10–30 min on a free Colab GPU
- **Replaced optunacy** with matplotlib + Optuna's built-in visualization (`plot_pareto_front`, `plot_param_importances`) — removes a fragile low-activity dependency
- **Fixed plot generation bugs** — all plots use the matplotlib backend (no plotly/browser dependency)
- **Fixed variable/function name collision** (`completed_trials`)
- **Added MPS device support** alongside CUDA
- **Cleaned up unused imports** (copy, random, numbers, multiprocessing, scipy, ThreadPoolExecutor)
- **Synced .rst with .ipynb** — both files have identical content and structure
- **Added tutorial to docs index** (Advanced Tutorials section)

The tutorial walks through:
1. Building a parameterizable SNN with configurable depth, width, timesteps, and decay
2. An adaptive early-stopping trainer that adjusts significance thresholds by network depth
3. A multi-objective Optuna study minimizing spikes while maximizing accuracy
4. Analysis with Pareto front, scatter plots, and hyperparameter importance charts

Tested with Optuna 4.x.