### PR TITLE
Refactor reset mechanisms SpikingNeuron base class and (R)Leaky definitions

### DIFF
--- a/snntorch/_neurons/leaky.py
+++ b/snntorch/_neurons/leaky.py
@@ -236,11 +236,12 @@ class Leaky(LIF):
             return spk, self.mem
 
     def _base_sub(self, input_): # reset by subtraction, soft reset
-        return self.beta.clamp(0, 1) * (self.mem - self.reset * self.threshold) + input_
+        base_fn = self._base_int(input_)
+        return base_fn - self.reset * self.threshold * self.beta.clamp(0, 1)
 
     def _base_zero(self, input_): # reset to zero, hard reset
         base_fn = self._base_int(input_)
-        return (1 - self.reset) * base_fn
+        return base_fn - self.reset * base_fn
 
     def _base_int(self, input_): # pure integration, no reset
         return self.beta.clamp(0, 1) * self.mem + input_

--- a/snntorch/_neurons/leaky.py
+++ b/snntorch/_neurons/leaky.py
@@ -235,19 +235,15 @@ class Leaky(LIF):
         else:
             return spk, self.mem
 
-    def _base_state_function(self, input_):
-        base_fn = self.beta.clamp(0, 1) * self.mem + input_
-        return base_fn
+    def _base_sub(self, input_): # reset by subtraction, soft reset
+        return self.beta.clamp(0, 1) * (self.mem - self.reset * self.threshold) + input_
 
-    def _base_sub(self, input_):
-        return self._base_state_function(input_) - self.reset * self.threshold
+    def _base_zero(self, input_): # reset to zero, hard reset
+        base_fn = self._base_int(input_)
+        return (1 - self.reset) * base_fn
 
-    def _base_zero(self, input_):
-        self.mem = (1 - self.reset) * self.mem
-        return self._base_state_function(input_)
-
-    def _base_int(self, input_):
-        return self._base_state_function(input_)
+    def _base_int(self, input_): # pure integration, no reset
+        return self.beta.clamp(0, 1) * self.mem + input_
 
     @classmethod
     def detach_hidden(cls):

--- a/snntorch/_neurons/leaky.py
+++ b/snntorch/_neurons/leaky.py
@@ -137,13 +137,6 @@ class Leaky(LIF):
 
     """
 
-    reset_dict = {
-        "subtract": 0,
-        "zero": 1,
-        "none": 2,
-        "subtract_beta": 3,
-    }
-
     def __init__(
         self,
         beta,
@@ -178,17 +171,6 @@ class Leaky(LIF):
         )
 
         self._init_mem()
-
-        match self.reset_mechanism_val:
-            case 0:
-                self._apply_reset = self._reset_sub_beta  # softer reset
-            case 1:
-                self._apply_reset = self._reset_sub  # soft reset
-            case 2:
-                self._apply_reset = self._reset_zero  # hard reset
-            case 3:
-                self._apply_reset = lambda reset: self.mem  # no reset
-
         self.reset_delay = reset_delay
 
     def _init_mem(self):
@@ -218,7 +200,7 @@ class Leaky(LIF):
 
         reset = self.mem_reset(self.mem)  # S[t]
         self.mem = self._base_state_function(input_)  # U[t+1] before reset
-        self.mem = self._apply_reset(reset)  # U[t+1] after reset
+        self.mem = self._reset_function(reset)  # U[t+1] after reset
 
         if self.state_quant:
             self.mem = self.state_quant(self.mem)
@@ -234,7 +216,7 @@ class Leaky(LIF):
             do_reset = (
                 spk / self.graded_spikes_factor - reset
             )  # avoid double reset
-            self.mem = self._apply_reset(do_reset)
+            self.mem = self._reset_function(do_reset)
 
         if self.init_hidden and not self.output:
             return spk
@@ -252,6 +234,16 @@ class Leaky(LIF):
 
     def _reset_zero(self, reset):  # reset to zero, hard reset
         return self.mem - reset * self.mem
+    
+    def _set_reset_function(self):
+        if self.reset_mechanism_val == 0:   # soft reset
+            self._reset_function = self._reset_sub
+        elif self.reset_mechanism_val == 1: # hard reset
+            self._reset_function = self._reset_zero
+        elif self.reset_mechanism_val == 2: # no reset
+            self._reset_function = lambda reset: self.mem
+        elif self.reset_mechanism_val == 3: # softer reset
+            self._reset_function = self._reset_sub_beta
 
     @classmethod
     def detach_hidden(cls):

--- a/snntorch/_neurons/leaky.py
+++ b/snntorch/_neurons/leaky.py
@@ -10,19 +10,19 @@ class Leaky(LIF):
     Membrane potential decays exponentially with rate beta.
     For :math:`U[T] > U_{\\rm thr} ⇒ S[T+1] = 1`.
 
-    If `reset_mechanism = "subtract"`, then :math:`U[t+1]` will have
-    `threshold` subtracted from it whenever the neuron emits a spike:
+    If `reset_mechanism = "subtract"` or `"subtract_beta"`, then :math:`U[t+1]` will have
+    `threshold` or `threshold * beta` subtracted from it whenever the neuron emits a spike:
 
     .. math::
 
-            U[t+1] = βU[t] + I_{\\rm in}[t+1] - RU_{\\rm thr}
+            U[t+1] = βU[t] + I_{\\rm in}[t+1] - [RU_{\\rm thr} \\text{ or } βRU_{\\rm thr}]
 
     If `reset_mechanism = "zero"`, then :math:`U[t+1]` will be set to `0`
     whenever the neuron emits a spike:
 
     .. math::
 
-            U[t+1] = βU[t] + I_{\\rm syn}[t+1] - R(βU[t] + I_{\\rm in}[t+1])
+            U[t+1] = βU[t] + I_{\\rm in}[t+1] - R(βU[t] + I_{\\rm in}[t+1])
 
     * :math:`I_{\\rm in}` - Input current
     * :math:`U` - Membrane potential
@@ -96,7 +96,7 @@ class Leaky(LIF):
 
     :param reset_mechanism: Defines the reset mechanism applied to \
     :math:`mem` each time the threshold is met. Reset-by-subtraction: \
-        "subtract", reset-to-zero: "zero", none: "none". Defaults to "subtract"
+        "subtract" or "subtract_beta", reset-to-zero: "zero", none: "none". Defaults to "subtract"
     :type reset_mechanism: str, optional
 
     :param state_quant: If specified, hidden state :math:`mem` is quantized
@@ -137,6 +137,13 @@ class Leaky(LIF):
 
     """
 
+    reset_dict = {
+        "subtract": 0,
+        "zero": 1,
+        "none": 2,
+        "subtract_beta": 3,
+    }
+
     def __init__(
         self,
         beta,
@@ -172,12 +179,15 @@ class Leaky(LIF):
 
         self._init_mem()
 
-        if self.reset_mechanism_val == 0:  # reset by subtraction
-            self.state_function = self._base_sub
-        elif self.reset_mechanism_val == 1:  # reset to zero
-            self.state_function = self._base_zero
-        elif self.reset_mechanism_val == 2:  # no reset, pure integration
-            self.state_function = self._base_int
+        match self.reset_mechanism_val:
+            case 0:
+                self._apply_reset = self._reset_sub_beta  # softer reset
+            case 1:
+                self._apply_reset = self._reset_sub  # soft reset
+            case 2:
+                self._apply_reset = self._reset_zero  # hard reset
+            case 3:
+                self._apply_reset = lambda reset: self.mem  # no reset
 
         self.reset_delay = reset_delay
 
@@ -206,8 +216,9 @@ class Leaky(LIF):
         if not self.mem.shape == input_.shape:
             self.mem = torch.zeros_like(input_, device=self.mem.device)
 
-        self.reset = self.mem_reset(self.mem)
-        self.mem = self.state_function(input_)
+        reset = self.mem_reset(self.mem)  # S[t]
+        self.mem = self._base_state_function(input_)  # U[t+1] before reset
+        self.mem = self._apply_reset(reset)  # U[t+1] after reset
 
         if self.state_quant:
             self.mem = self.state_quant(self.mem)
@@ -217,34 +228,32 @@ class Leaky(LIF):
                 self.mem.size(0), self.mem
             )  # batch_size
         else:
-            spk = self.fire(self.mem)
+            spk = self.fire(self.mem)  # S[t+1]
 
         if not self.reset_delay:
             do_reset = (
-                spk / self.graded_spikes_factor - self.reset
+                spk / self.graded_spikes_factor - reset
             )  # avoid double reset
-            if self.reset_mechanism_val == 0:  # reset by subtraction
-                self.mem = self.mem - do_reset * self.threshold
-            elif self.reset_mechanism_val == 1:  # reset to zero
-                self.mem = self.mem - do_reset * self.mem
+            self.mem = self._apply_reset(do_reset)
 
-        if self.output:
-            return spk, self.mem
-        elif self.init_hidden:
+        if self.init_hidden and not self.output:
             return spk
         else:
             return spk, self.mem
 
-    def _base_sub(self, input_): # reset by subtraction, soft reset
-        base_fn = self._base_int(input_)
-        return base_fn - self.reset * self.threshold * self.beta.clamp(0, 1)
-
-    def _base_zero(self, input_): # reset to zero, hard reset
-        base_fn = self._base_int(input_)
-        return base_fn - self.reset * base_fn
-
-    def _base_int(self, input_): # pure integration, no reset
+    def _base_state_function(self, input_):
         return self.beta.clamp(0, 1) * self.mem + input_
+
+    def _reset_sub_beta(
+        self, reset
+    ):  # reset by subtraction * beta, softer reset
+        return self.mem - reset * self.threshold * self.beta.clamp(0, 1)
+
+    def _reset_sub(self, reset):  # reset by subtraction, soft reset
+        return self.mem - reset * self.threshold
+
+    def _reset_zero(self, reset):  # reset to zero, hard reset
+        return self.mem - reset * self.mem
 
     @classmethod
     def detach_hidden(cls):

--- a/snntorch/_neurons/leaky.py
+++ b/snntorch/_neurons/leaky.py
@@ -244,9 +244,7 @@ class Leaky(LIF):
     def _base_state_function(self, input_):
         return self.beta.clamp(0, 1) * self.mem + input_
 
-    def _reset_sub_beta(
-        self, reset
-    ):  # reset by subtraction * beta, softer reset
+    def _reset_sub_beta(self, reset):  # reset by sub. * beta, softer reset
         return self.mem - reset * self.threshold * self.beta.clamp(0, 1)
 
     def _reset_sub(self, reset):  # reset by subtraction, soft reset

--- a/snntorch/_neurons/neurons.py
+++ b/snntorch/_neurons/neurons.py
@@ -22,11 +22,10 @@ class SpikingNeuron(nn.Module):
     The list is used to initialize and clear neuron states when the
     argument `init_hidden=True`."""
 
-    reset_dict = {
-        "subtract": 0,
-        "zero": 1,
-        "none": 2,
-    }
+    reset_dict = {'none': 0}
+    """Each :mod:`snntorch.SpikingNeuron` neuron 
+    (e.g., :mod:`snntorch.Leaky`) defines its own mapping of reset mechanisms
+    to its corresponding reset function in the class variable `reset_dict`."""
 
     def __init__(
         self,
@@ -36,7 +35,7 @@ class SpikingNeuron(nn.Module):
         init_hidden=False,
         inhibition=False,
         learn_threshold=False,
-        reset_mechanism="subtract",
+        reset_mechanism="none",
         state_quant=False,
         output=False,
         graded_spikes_factor=1.0,
@@ -178,6 +177,7 @@ class SpikingNeuron(nn.Module):
             type(self).reset_dict[reset_mechanism]
         )
         self.register_buffer("reset_mechanism_val", reset_mechanism_val)
+        self.reset_mechanism = reset_mechanism
 
     def _V_register_buffer(self, V, learn_V):
         if not isinstance(V, torch.Tensor):
@@ -200,6 +200,10 @@ class SpikingNeuron(nn.Module):
             type(self).reset_dict[new_reset_mechanism]
         )
         self._reset_mechanism = new_reset_mechanism
+        self._set_reset_function()
+
+    def _set_reset_function(self):
+        pass # to be implemented in child classes
 
     @classmethod
     def init(cls):
@@ -229,6 +233,13 @@ class SpikingNeuron(nn.Module):
 
 class LIF(SpikingNeuron):
     """Parent class for leaky integrate and fire neuron models."""
+
+    reset_dict = {
+        "subtract": 0,
+        "zero": 1,
+        "none": 2,
+        "subtract_beta": 3,
+    }
 
     def __init__(
         self,

--- a/snntorch/_neurons/neurons.py
+++ b/snntorch/_neurons/neurons.py
@@ -118,14 +118,10 @@ class SpikingNeuron(nn.Module):
             )
 
     def _reset_cases(self, reset_mechanism):
-        if (
-            reset_mechanism != "subtract"
-            and reset_mechanism != "zero"
-            and reset_mechanism != "none"
-        ):
+        if reset_mechanism not in type(self).reset_dict:
             raise ValueError(
-                "reset_mechanism must be set to either 'subtract', "
-                "'zero', or 'none'."
+                "reset_mechanism must be set to one of "
+                ", ".join(f"`{k}`" for k in type(self).reset_dict) + "."
             )
 
     def _snn_register_buffer(
@@ -149,7 +145,7 @@ class SpikingNeuron(nn.Module):
             # if reset_mechanism_val is loaded from .pt, override
             # reset_mechanism
             if torch.is_tensor(self.reset_mechanism_val):
-                self.reset_mechanism = list(SpikingNeuron.reset_dict)[
+                self.reset_mechanism = list(type(self).reset_dict)[
                     self.reset_mechanism_val
                 ]
         except AttributeError:
@@ -179,7 +175,7 @@ class SpikingNeuron(nn.Module):
         Must be of type tensor to store in register buffer. See reset_dict
         for mapping."""
         reset_mechanism_val = torch.as_tensor(
-            SpikingNeuron.reset_dict[reset_mechanism]
+            type(self).reset_dict[reset_mechanism]
         )
         self.register_buffer("reset_mechanism_val", reset_mechanism_val)
 
@@ -194,15 +190,14 @@ class SpikingNeuron(nn.Module):
     @property
     def reset_mechanism(self):
         """If reset_mechanism is modified, reset_mechanism_val is triggered
-        to update.
-        0: subtract, 1: zero, 2: none."""
+        to update."""
         return self._reset_mechanism
 
     @reset_mechanism.setter
     def reset_mechanism(self, new_reset_mechanism):
         self._reset_cases(new_reset_mechanism)
         self.reset_mechanism_val = torch.as_tensor(
-            SpikingNeuron.reset_dict[new_reset_mechanism]
+            type(self).reset_dict[new_reset_mechanism]
         )
         self._reset_mechanism = new_reset_mechanism
 

--- a/snntorch/_neurons/rleaky.py
+++ b/snntorch/_neurons/rleaky.py
@@ -172,8 +172,9 @@ class RLeaky(LIF):
 
     :param reset_mechanism: Defines the reset mechanism applied to
         :math:`mem` each time the threshold is met.
-        Reset-by-subtraction: "subtract", reset-to-zero: "zero",
-        none: "none". Defaults to "subtract"
+        Reset-by-subtraction: "subtract", 
+        Reset-by-subtraction-beta: "subtract_beta", 
+        reset-to-zero: "zero",none: "none". Defaults to "subtract"
     :type reset_mechanism: str, optional
 
     :param state_quant: If specified, hidden state :math:`mem` is
@@ -221,6 +222,13 @@ class RLeaky(LIF):
             (input_size).
 
     """
+
+    reset_dict = {
+        "subtract": 0,
+        "zero": 1,
+        "none": 2,
+        "subtract_beta": 3,
+    }
 
     def __init__(
         self,
@@ -282,12 +290,15 @@ class RLeaky(LIF):
 
         self._init_mem()
 
-        if self.reset_mechanism_val == 0:  # reset by subtraction
-            self.state_function = self._base_sub
-        elif self.reset_mechanism_val == 1:  # reset to zero
-            self.state_function = self._base_zero
-        elif self.reset_mechanism_val == 2:  # no reset, pure integration
-            self.state_function = self._base_int
+        match self.reset_mechanism_val:
+            case 0:
+                self._apply_reset = self._reset_sub_beta  # softer reset
+            case 1:
+                self._apply_reset = self._reset_sub  # soft reset
+            case 2:
+                self._apply_reset = self._reset_zero  # hard reset
+            case 3:
+                self._apply_reset = lambda reset: self.mem  # no reset
 
         self.reset_delay = reset_delay
 
@@ -330,8 +341,9 @@ class RLeaky(LIF):
         # self.beta.clamp_min(0)), giving actual time constants instead of
         # values in [0, 1] as initial beta beta = self.beta.clamp(0, 1)
 
-        self.reset = self.mem_reset(self.mem)
-        self.mem = self.state_function(input_)
+        reset = self.mem_reset(self.mem)  # S[t]
+        self.mem = self._base_state_function(input_)  # U[t+1] before reset
+        self.mem = self._apply_reset(reset)  # U[t+1] after reset
 
         if self.state_quant:
             self.mem = self.state_quant(self.mem)
@@ -343,12 +355,9 @@ class RLeaky(LIF):
 
         if not self.reset_delay:
             do_reset = (
-                self.spk / self.graded_spikes_factor - self.reset
+                self.spk / self.graded_spikes_factor - reset
             )  # avoid double reset
-            if self.reset_mechanism_val == 0:  # reset by subtraction
-                self.mem = self.mem - do_reset * self.threshold
-            elif self.reset_mechanism_val == 1:  # reset to zero
-                self.mem = self.mem - do_reset * self.mem
+            self.mem = self._apply_reset(do_reset)
 
         if self.output:
             return self.spk, self.mem
@@ -399,16 +408,16 @@ class RLeaky(LIF):
         )
         return base_fn
 
-    def _base_sub(self, input_):
-        return self._base_state_function(input_) - self.reset * self.threshold
+    def _reset_sub_beta(
+        self, reset
+    ):  # reset by subtraction * beta, softer reset
+        return self.mem - reset * self.threshold * self.beta.clamp(0, 1)
 
-    def _base_zero(self, input_):
-        return self._base_state_function(
-            input_
-        ) - self.reset * self._base_state_function(input_)
+    def _reset_sub(self, reset):  # reset by subtraction, soft reset
+        return self.mem - reset * self.threshold
 
-    def _base_int(self, input_):
-        return self._base_state_function(input_)
+    def _reset_zero(self, reset):  # reset to zero, hard reset
+        return self.mem - reset * self.mem
 
     def _rleaky_init_cases(self):
         all_to_all_bool = bool(self.all_to_all)

--- a/snntorch/_neurons/rleaky.py
+++ b/snntorch/_neurons/rleaky.py
@@ -223,12 +223,6 @@ class RLeaky(LIF):
 
     """
 
-    reset_dict = {
-        "subtract": 0,
-        "zero": 1,
-        "none": 2,
-        "subtract_beta": 3,
-    }
 
     def __init__(
         self,
@@ -289,17 +283,6 @@ class RLeaky(LIF):
             self._disable_recurrent_grad()
 
         self._init_mem()
-
-        match self.reset_mechanism_val:
-            case 0:
-                self._apply_reset = self._reset_sub_beta  # softer reset
-            case 1:
-                self._apply_reset = self._reset_sub  # soft reset
-            case 2:
-                self._apply_reset = self._reset_zero  # hard reset
-            case 3:
-                self._apply_reset = lambda reset: self.mem  # no reset
-
         self.reset_delay = reset_delay
 
     def _init_mem(self):
@@ -343,7 +326,7 @@ class RLeaky(LIF):
 
         reset = self.mem_reset(self.mem)  # S[t]
         self.mem = self._base_state_function(input_)  # U[t+1] before reset
-        self.mem = self._apply_reset(reset)  # U[t+1] after reset
+        self.mem = self._reset_function(reset)  # U[t+1] after reset
 
         if self.state_quant:
             self.mem = self.state_quant(self.mem)
@@ -357,7 +340,7 @@ class RLeaky(LIF):
             do_reset = (
                 self.spk / self.graded_spikes_factor - reset
             )  # avoid double reset
-            self.mem = self._apply_reset(do_reset)
+            self.mem = self._reset_function(do_reset)
 
         if self.output:
             return self.spk, self.mem
@@ -408,9 +391,7 @@ class RLeaky(LIF):
         )
         return base_fn
 
-    def _reset_sub_beta(
-        self, reset
-    ):  # reset by subtraction * beta, softer reset
+    def _reset_sub_beta(self, reset):  # reset by sub. * beta, softer reset
         return self.mem - reset * self.threshold * self.beta.clamp(0, 1)
 
     def _reset_sub(self, reset):  # reset by subtraction, soft reset
@@ -418,6 +399,16 @@ class RLeaky(LIF):
 
     def _reset_zero(self, reset):  # reset to zero, hard reset
         return self.mem - reset * self.mem
+    
+    def _set_reset_function(self):
+        if self.reset_mechanism_val == 0:   # soft reset
+            self._reset_function = self._reset_sub
+        elif self.reset_mechanism_val == 1: # hard reset
+            self._reset_function = self._reset_zero
+        elif self.reset_mechanism_val == 2: # no reset
+            self._reset_function = lambda reset: self.mem
+        elif self.reset_mechanism_val == 3: # softer reset
+            self._reset_function = self._reset_sub_beta
 
     def _rleaky_init_cases(self):
         all_to_all_bool = bool(self.all_to_all)

--- a/snntorch/_neurons/sconv2dlstm.py
+++ b/snntorch/_neurons/sconv2dlstm.py
@@ -207,6 +207,12 @@ class SConv2dLSTM(SpikingNeuron):
 
     """
 
+    reset_dict = {
+        "subtract": 0,
+        "zero": 1,
+        "none": 2,
+    }
+
     def __init__(
         self,
         in_channels,
@@ -239,13 +245,6 @@ class SConv2dLSTM(SpikingNeuron):
         )
 
         self._init_mem()
-
-        if self.reset_mechanism_val == 0:  # reset by subtraction
-            self.state_function = self._base_sub
-        elif self.reset_mechanism_val == 1:  # reset to zero
-            self.state_function = self._base_zero
-        elif self.reset_mechanism_val == 2:  # no reset, pure integration
-            self.state_function = self._base_int
 
         self.in_channels = in_channels
         self.out_channels = out_channels
@@ -388,6 +387,14 @@ class SConv2dLSTM(SpikingNeuron):
                 "Only one of either `max_pool` or `avg_pool` may be "
                 "specified, not both."
             )
+
+    def _set_reset_function(self):
+        if self.reset_mechanism_val == 0:  # reset by subtraction
+            self.state_function = self._base_sub
+        elif self.reset_mechanism_val == 1:  # reset to zero
+            self.state_function = self._base_zero
+        elif self.reset_mechanism_val == 2:  # no reset, pure integration
+            self.state_function = self._base_int
 
     @classmethod
     def detach_hidden(cls):

--- a/snntorch/_neurons/slstm.py
+++ b/snntorch/_neurons/slstm.py
@@ -157,6 +157,12 @@ class SLSTM(SpikingNeuron):
 
     """
 
+    reset_dict = {
+        "subtract": 0,
+        "zero": 1,
+        "none": 2,
+    }
+
     def __init__(
         self,
         input_size,
@@ -186,13 +192,6 @@ class SLSTM(SpikingNeuron):
         )
 
         self._init_mem()
-
-        if self.reset_mechanism_val == 0:  # reset by subtraction
-            self.state_function = self._base_sub
-        elif self.reset_mechanism_val == 1:  # reset to zero
-            self.state_function = self._base_zero
-        elif self.reset_mechanism_val == 2:  # no reset, pure integration
-            self.state_function = self._base_int
 
         self.input_size = input_size
         self.hidden_size = hidden_size
@@ -279,6 +278,14 @@ class SLSTM(SpikingNeuron):
 
     def _base_int(self, input_):
         return self._base_state_function(input_)
+    
+    def _set_reset_function(self):
+        if self.reset_mechanism_val == 0:  # reset by subtraction
+            self.state_function = self._base_sub
+        elif self.reset_mechanism_val == 1:  # reset to zero
+            self.state_function = self._base_zero
+        elif self.reset_mechanism_val == 2:  # no reset, pure integration
+            self.state_function = self._base_int
 
     @classmethod
     def detach_hidden(cls):


### PR DESCRIPTION
The reset mechanisms in the Leaky class got broken in version 0.08 where they got refactored a bit.  
Both soft and hard reset mechanisms do not function as expected: currently the default soft reset resets to zero, whereas the hard reset resets by subtraction -- see [this open issue](https://github.com/jeshraghian/snntorch/issues/341), or you may see for yourself by running tutorial 3 with the current release of snntorch (0.9.4).
To address this:

1. Refactored `SpikingNeuron` parent class to more easily allow for custom reset implementations. Instead of only accepting 'subtract', 'zero', and 'none', custom `reset_dict` can now be redefined in child classes.
2. Fixed `@reset_mechanism.setter` to actually change the reset mechanism when altered. This comes with the introduction of the `_set_reset_function()` function, to be overwritten in child neuron classes.
3. Refactored reset mechanisms in `Leaky` (and `RLeaky`) for clarity and to function as expected:
-  `subtract_beta` -> $U[t+1] = \beta U[t] + I[t+1] - \beta R U_{\rm thr}$
-  `subtract` -> $U[t+1] = \beta U[t] + I[t+1] - R U_{\rm thr}$
-  `zero` -> $U[t+1] = \beta U[t] + I[t+1] - R (\beta U[t] + I[t+1])$
-  `none` -> $U[t+1] = \beta U[t] + I[t+1]$