### PR TITLE
Fix 420 picklable atan

### DIFF
--- a/snntorch/surrogate.py
+++ b/snntorch/surrogate.py
@@ -7,6 +7,7 @@ import math
 # """``snntorch.surrogate.slope``
 # parameterizes the transition rate of the surrogate gradients."""
 
+
 class ATanSurrogate:
     def __init__(self, alpha=2.0):
         self.alpha = alpha
@@ -17,6 +18,7 @@ class ATanSurrogate:
 
 def atan(alpha=2.0):
     return ATanSurrogate(alpha)
+
 
 class StraightThroughEstimator(torch.autograd.Function):
     """
@@ -213,9 +215,6 @@ class ATan(torch.autograd.Function):
         return grad, None
 
 
-
-
-
 # @staticmethod
 class Heaviside(torch.autograd.Function):
     """Default spiking function for neuron.
@@ -385,7 +384,6 @@ def spike_rate_escape(beta=1, slope=25):
 
 
 class StochasticSpikeOperator(torch.autograd.Function):
-
     """
     Surrogate gradient of the Heaviside step function.
 
@@ -441,7 +439,7 @@ class StochasticSpikeOperator(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, grad_output):
-        (input_, out) = ctx.saved_tensors
+        input_, out = ctx.saved_tensors
         grad_input = grad_output.clone()
         grad = grad_input * out + (grad_input * (~out.bool()).float()) * (
             (torch.rand_like(input_) - 0.5 + ctx.mean) * ctx.variance
@@ -462,7 +460,6 @@ def SSO(mean=0, variance=0.2):
 
 
 class LeakySpikeOperator(torch.autograd.Function):
-
     """
     Surrogate gradient of the Heaviside step function.
 

--- a/snntorch/surrogate.py
+++ b/snntorch/surrogate.py
@@ -7,6 +7,16 @@ import math
 # """``snntorch.surrogate.slope``
 # parameterizes the transition rate of the surrogate gradients."""
 
+class ATanSurrogate:
+    def __init__(self, alpha=2.0):
+        self.alpha = alpha
+
+    def __call__(self, x):
+        return ATan.apply(x, self.alpha)
+
+
+def atan(alpha=2.0):
+    return ATanSurrogate(alpha)
 
 class StraightThroughEstimator(torch.autograd.Function):
     """
@@ -203,14 +213,7 @@ class ATan(torch.autograd.Function):
         return grad, None
 
 
-def atan(alpha=2.0):
-    """ArcTan surrogate gradient enclosed with a parameterized slope."""
-    alpha = alpha
 
-    def inner(x):
-        return ATan.apply(x, alpha)
-
-    return inner
 
 
 # @staticmethod

--- a/tests/test_surrogate_pickle.py
+++ b/tests/test_surrogate_pickle.py
@@ -1,0 +1,11 @@
+import torch
+import snntorch as snn
+
+
+def test_leaky_torch_save_roundtrip(tmp_path):
+    net = snn.Leaky(beta=0.9)
+    path = tmp_path / "model.pt"
+    torch.save(net, path)
+    net2 = torch.load(path, weights_only=False)
+    assert isinstance(net2, snn.Leaky)
+    

--- a/tests/test_surrogate_pickle.py
+++ b/tests/test_surrogate_pickle.py
@@ -8,4 +8,3 @@ def test_leaky_torch_save_roundtrip(tmp_path):
     torch.save(net, path)
     net2 = torch.load(path, weights_only=False)
     assert isinstance(net2, snn.Leaky)
-    


### PR DESCRIPTION
Fixes #420.

Problem
`torch.save` fails on the default surrogate gradient because `atan()` returns a closure (`atan.<locals>.inner`). Pickle needs a module-level importable path to serialize a function; a closure defined inside another function has none.

Fix
Replaced the closure with `ATanSurrogate`, a picklable class defined at module top level in `surrogate.py`. `__init__` stores `alpha`, `__call__` reproduces the original computation. `atan()` now returns an instance of this class instead of the closure, so the call interface (`atan(alpha=2.0)` → callable with `x`) is unchanged.

Testing
Added `tests/test_surrogate_pickle.py`: builds a `Leaky` neuron, round-trips through `torch.save`/`torch.load`.

Fails on `master` with the exact reported error (`AttributeError: Can't pickle local object 'atan.<locals>.inner'`), passes with this fix. Full suite: 142 passed, 2 xfailed (was 141 passed, 2 xfailed).