### PR TITLE
Preserve input dtype in neuron modules and surrogate gradients

### DIFF
--- a/snntorch/_neurons/leakykernel.py
+++ b/snntorch/_neurons/leakykernel.py
@@ -217,7 +217,7 @@ class LeakyKernel(nn.Module):
 
     @staticmethod
     def _surrogate_bypass(input_):
-        return (input_ > 0).float()
+        return (input_ > 0).to(input_.dtype)
 
     @staticmethod
     class ATan(torch.autograd.Function):
@@ -255,7 +255,7 @@ class LeakyKernel(nn.Module):
         def forward(ctx, input_, alpha=2.0):
             ctx.save_for_backward(input_)
             ctx.alpha = alpha
-            out = (input_ > 0).float()
+            out = (input_ > 0).to(input_.dtype)
             return out
 
         @staticmethod

--- a/snntorch/_neurons/leakyparallel.py
+++ b/snntorch/_neurons/leakyparallel.py
@@ -218,7 +218,7 @@ class LeakyParallel(nn.Module):
 
     @staticmethod
     def _surrogate_bypass(input_):
-        return (input_ > 0).float()
+        return (input_ > 0).to(input_.dtype)
 
     @staticmethod
     class ATan(torch.autograd.Function):
@@ -256,7 +256,7 @@ class LeakyParallel(nn.Module):
         def forward(ctx, input_, alpha=2.0):
             ctx.save_for_backward(input_)
             ctx.alpha = alpha
-            out = (input_ > 0).float()
+            out = (input_ > 0).to(input_.dtype)
             return out
 
         @staticmethod

--- a/snntorch/_neurons/leakyunroll.py
+++ b/snntorch/_neurons/leakyunroll.py
@@ -221,7 +221,7 @@ class LeakyParallel(nn.Module):
 
     @staticmethod
     def _surrogate_bypass(input_):
-        return (input_ > 0).float()
+        return (input_ > 0).to(input_.dtype)
 
     @staticmethod
     class ATan(torch.autograd.Function):
@@ -259,7 +259,7 @@ class LeakyParallel(nn.Module):
         def forward(ctx, input_, alpha=2.0):
             ctx.save_for_backward(input_)
             ctx.alpha = alpha
-            out = (input_ > 0).float()
+            out = (input_ > 0).to(input_.dtype)
             return out
 
         @staticmethod

--- a/snntorch/_neurons/neurons.py
+++ b/snntorch/_neurons/neurons.py
@@ -229,7 +229,7 @@ class SpikingNeuron(nn.Module):
 
     @staticmethod
     def _surrogate_bypass(input_):
-        return (input_ > 0).float()
+        return (input_ > 0).to(input_.dtype)
 
 
 class LIF(SpikingNeuron):

--- a/snntorch/_neurons/sconv2dlstm.py
+++ b/snntorch/_neurons/sconv2dlstm.py
@@ -303,10 +303,14 @@ class SConv2dLSTM(SpikingNeuron):
         size = input_.size()
         correct_shape = (size[0], self.out_channels, size[2], size[3])
         if not self.syn.shape == correct_shape:
-            self.syn = torch.zeros(correct_shape, device=self.syn.device)
+            self.syn = torch.zeros(
+                correct_shape, device=self.syn.device, dtype=input_.dtype
+            )
 
         if not self.mem.shape == correct_shape:
-            self.mem = torch.zeros(correct_shape, device=self.mem.device)
+            self.mem = torch.zeros(
+                correct_shape, device=self.mem.device, dtype=input_.dtype
+            )
 
         self.reset = self.mem_reset(self.mem)
         self.syn, self.mem = self.state_function(input_)

--- a/snntorch/_neurons/slstm.py
+++ b/snntorch/_neurons/slstm.py
@@ -234,10 +234,14 @@ class SLSTM(SpikingNeuron):
         correct_shape = (size[0], self.hidden_size)
 
         if not self.syn.shape == input_.shape:
-            self.syn = torch.zeros(correct_shape, device=self.syn.device)
+            self.syn = torch.zeros(
+                correct_shape, device=self.syn.device, dtype=input_.dtype
+            )
 
         if not self.mem.shape == input_.shape:
-            self.mem = torch.zeros(correct_shape, device=self.mem.device)
+            self.mem = torch.zeros(
+                correct_shape, device=self.mem.device, dtype=input_.dtype
+            )
 
         self.reset = self.mem_reset(self.mem)
         self.syn, self.mem = self.state_function(input_)

--- a/snntorch/surrogate.py
+++ b/snntorch/surrogate.py
@@ -31,7 +31,7 @@ class StraightThroughEstimator(torch.autograd.Function):
 
     @staticmethod
     def forward(ctx, input_):
-        out = (input_ > 0).float()
+        out = (input_ > 0).to(input_.dtype)
         return out
 
     @staticmethod
@@ -78,7 +78,7 @@ class Triangular(torch.autograd.Function):
     def forward(ctx, input_, threshold):
         ctx.save_for_backward(input_)
         ctx.threshold = threshold
-        out = (input_ > 0).float()
+        out = (input_ > 0).to(input_.dtype)
         return out
 
     @staticmethod
@@ -132,7 +132,7 @@ class FastSigmoid(torch.autograd.Function):
     def forward(ctx, input_, slope):
         ctx.save_for_backward(input_)
         ctx.slope = slope
-        out = (input_ > 0).float()
+        out = (input_ > 0).to(input_.dtype)
         return out
 
     @staticmethod
@@ -187,7 +187,7 @@ class ATan(torch.autograd.Function):
     def forward(ctx, input_, alpha):
         ctx.save_for_backward(input_)
         ctx.alpha = alpha
-        out = (input_ > 0).float()
+        out = (input_ > 0).to(input_.dtype)
         return out
 
     @staticmethod
@@ -240,7 +240,7 @@ class Heaviside(torch.autograd.Function):
 
     @staticmethod
     def forward(ctx, input_):
-        out = (input_ > 0).float()
+        out = (input_ > 0).to(input_.dtype)
         ctx.save_for_backward(out)
         return out
 
@@ -294,7 +294,7 @@ class Sigmoid(torch.autograd.Function):
     def forward(ctx, input_, slope):
         ctx.save_for_backward(input_)
         ctx.slope = slope
-        out = (input_ > 0).float()
+        out = (input_ > 0).to(input_.dtype)
         return out
 
     @staticmethod
@@ -355,7 +355,7 @@ class SpikeRateEscape(torch.autograd.Function):
         ctx.save_for_backward(input_)
         ctx.beta = beta
         ctx.slope = slope
-        out = (input_ > 0).float()
+        out = (input_ > 0).to(input_.dtype)
         return out
 
     def backward(ctx, grad_output):
@@ -430,7 +430,7 @@ class StochasticSpikeOperator(torch.autograd.Function):
 
     @staticmethod
     def forward(ctx, input_, mean, variance):
-        out = (input_ > 0).float()
+        out = (input_ > 0).to(input_.dtype)
         ctx.save_for_backward(input_, out)
         ctx.mean = mean
         ctx.variance = variance
@@ -492,7 +492,7 @@ class LeakySpikeOperator(torch.autograd.Function):
 
     @staticmethod
     def forward(ctx, input_, slope):
-        out = (input_ > 0).float()
+        out = (input_ > 0).to(input_.dtype)
         ctx.save_for_backward(out)
         ctx.slope = slope
         return out
@@ -554,7 +554,7 @@ class SparseFastSigmoid(torch.autograd.Function):
         ctx.save_for_backward(input_)
         ctx.slope = slope
         ctx.B = B
-        out = (input_ > 0).float()
+        out = (input_ > 0).to(input_.dtype)
         return out
 
     @staticmethod
@@ -644,7 +644,7 @@ class CustomSurrogate(torch.autograd.Function):
 
     @staticmethod
     def forward(ctx, input_, custom_surrogate_function):
-        out = (input_ > 0).float()
+        out = (input_ > 0).to(input_.dtype)
         ctx.save_for_backward(input_, out)
         ctx.custom_surrogate_function = custom_surrogate_function
         return out

--- a/tests/test_snntorch/test_dtypes.py
+++ b/tests/test_snntorch/test_dtypes.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python
+
+"""Tests for dtype preservation across neuron modules and surrogate
+gradients (issues #421 and #422)."""
+
+import pytest
+import snntorch as snn
+from snntorch import surrogate
+import torch
+
+DTYPES = [torch.float32, torch.float64]
+
+
+def _dtype_input(dtype):
+    return torch.randn(2, 4, dtype=dtype)
+
+
+class TestNeuronDtypePreservation:
+    @pytest.mark.parametrize("dtype", DTYPES)
+    def test_leaky_dtype(self, dtype):
+        x = _dtype_input(dtype)
+        lif = snn.Leaky(beta=0.9).to(dtype)
+        spk, mem = lif(x)
+        assert spk.dtype == dtype
+        assert mem.dtype == dtype
+
+    @pytest.mark.parametrize("dtype", DTYPES)
+    def test_synaptic_dtype(self, dtype):
+        x = _dtype_input(dtype)
+        lif = snn.Synaptic(alpha=0.8, beta=0.9).to(dtype)
+        spk, syn, mem = lif(x)
+        assert spk.dtype == dtype
+        assert syn.dtype == dtype
+        assert mem.dtype == dtype
+
+    @pytest.mark.parametrize("dtype", DTYPES)
+    def test_alpha_dtype(self, dtype):
+        x = _dtype_input(dtype)
+        lif = snn.Alpha(alpha=0.9, beta=0.8).to(dtype)
+        spk, syn_exc, syn_inh, mem = lif(x)
+        assert spk.dtype == dtype
+        assert mem.dtype == dtype
+
+    @pytest.mark.parametrize("dtype", DTYPES)
+    def test_lapicque_dtype(self, dtype):
+        x = _dtype_input(dtype)
+        lif = snn.Lapicque(beta=0.9).to(dtype)
+        spk, mem = lif(x)
+        assert spk.dtype == dtype
+        assert mem.dtype == dtype
+
+    @pytest.mark.parametrize("dtype", DTYPES)
+    def test_rleaky_dtype(self, dtype):
+        # issue #421: second step fed the float32 spike back into the
+        # recurrent layer and crashed under float64
+        x = _dtype_input(dtype)
+        lif = snn.RLeaky(beta=0.9, linear_features=4).to(dtype)
+        spk, mem = lif(x)
+        spk, mem = lif(x, spk, mem)
+        assert spk.dtype == dtype
+        assert mem.dtype == dtype
+
+    @pytest.mark.parametrize("dtype", DTYPES)
+    def test_rsynaptic_dtype(self, dtype):
+        x = _dtype_input(dtype)
+        lif = snn.RSynaptic(alpha=0.8, beta=0.9, linear_features=4).to(dtype)
+        spk, syn, mem = lif(x)
+        spk, syn, mem = lif(x, spk, syn, mem)
+        assert spk.dtype == dtype
+        assert syn.dtype == dtype
+        assert mem.dtype == dtype
+
+    @pytest.mark.parametrize("dtype", DTYPES)
+    def test_leaky_parallel_dtype(self, dtype):
+        x = torch.randn(3, 2, 4, dtype=dtype)
+        lif = snn.LeakyParallel(input_size=4, hidden_size=4).to(dtype)
+        spk = lif(x)
+        assert spk.dtype == dtype
+
+    @pytest.mark.parametrize("dtype", DTYPES)
+    def test_slstm_dtype(self, dtype):
+        x = _dtype_input(dtype)
+        lif = snn.SLSTM(input_size=4, hidden_size=4).to(dtype)
+        spk, syn, mem = lif(x)
+        spk, syn, mem = lif(x, syn, mem)
+        assert spk.dtype == dtype
+        assert syn.dtype == dtype
+        assert mem.dtype == dtype
+
+    @pytest.mark.parametrize("dtype", DTYPES)
+    def test_sconv2dlstm_dtype(self, dtype):
+        x = torch.randn(2, 3, 8, 8, dtype=dtype)
+        lif = snn.SConv2dLSTM(in_channels=3, out_channels=5, kernel_size=3).to(
+            dtype
+        )
+        spk, syn, mem = lif(x)
+        assert spk.dtype == dtype
+        assert syn.dtype == dtype
+        assert mem.dtype == dtype
+
+    @pytest.mark.parametrize("dtype", DTYPES)
+    def test_surrogate_disable_dtype(self, dtype):
+        x = _dtype_input(dtype)
+        lif = snn.Leaky(beta=0.9, surrogate_disable=True).to(dtype)
+        spk, mem = lif(x)
+        assert spk.dtype == dtype
+        assert mem.dtype == dtype
+
+
+class TestSurrogateDtypePreservation:
+    @pytest.mark.parametrize("dtype", DTYPES)
+    @pytest.mark.parametrize(
+        "spike_grad",
+        [
+            surrogate.atan(),
+            surrogate.fast_sigmoid(),
+            surrogate.sigmoid(),
+            surrogate.triangular(),
+            surrogate.straight_through_estimator(),
+            surrogate.heaviside(),
+            surrogate.spike_rate_escape(),
+            surrogate.SSO(),
+            surrogate.SFS(),
+        ],
+    )
+    def test_surrogate_forward_backward_dtype(self, spike_grad, dtype):
+        x = torch.randn(5, dtype=dtype, requires_grad=True)
+        spk = spike_grad(x)
+        spk.sum().backward()
+        assert spk.dtype == dtype
+        assert x.grad.dtype == dtype


### PR DESCRIPTION
Fixes #421, fixes #422.

### Problem

All surrogate gradient forward passes emit spikes with `(input_ > 0).float()`, which hard-casts the spike tensor to `float32` regardless of the input dtype. Two consequences:

1. **#422** — every neuron module (`Leaky`, `Synaptic`, `Alpha`, `Lapicque`, `RLeaky`, `RSynaptic`, `LeakyParallel`, `SLSTM`, ...) returns `float32` spikes even when the module and inputs are `float64`.
2. **#421** — in recurrent neurons the spike is fed back into the recurrent layer on the next step, so under `.double()` the `float32` spike hits the `float64` `nn.Linear` and raises `RuntimeError: mat1 and mat2 must have the same dtype`. (The first forward call succeeds; the failure appears on the second step, or immediately inside a multi-step loop.)

`SLSTM`/`SConv2dLSTM` additionally re-initialize their hidden states with `torch.zeros(shape)` without a `dtype`, which produces `float32` states for `float64` inputs and would crash inside `nn.LSTMCell` the same way.

### Changes

- `snntorch/surrogate.py`: all surrogate forward passes now emit `(input_ > 0).to(input_.dtype)`.
- `snntorch/_neurons/neurons.py`, `leakyparallel.py`, `leakykernel.py`, `leakyunroll.py`: same fix in `_surrogate_bypass` and the module-private `ATan` surrogates.
- `snntorch/_neurons/slstm.py`, `sconv2dlstm.py`: hidden-state re-initialization uses `dtype=input_.dtype`.

The `float32` masks in some backward passes (e.g. `(~out.bool()).float()`) are left untouched: they multiply into the incoming gradient, so `float64` gradients are preserved by type promotion. Happy to convert those as well if you'd prefer full consistency.

### Tests

New `tests/test_snntorch/test_dtypes.py`, parametrized over dtype × module and dtype × surrogate (38 tests):

- output spike/state dtypes for all modules listed in #422,
- the two-step recurrent case from #421 that previously crashed (`RLeaky`, `RSynaptic`, `SLSTM`),
- forward *and* backward (gradient) dtype for all nine surrogates,
- `surrogate_disable=True` path.

19 of the tests fail on master without this change. Full suite: 190 passed, 2 xfailed.
