### PR TITLE
Fix NaN gradients in sigmoid surrogate backward pass

### DIFF
--- a/snntorch/surrogate.py
+++ b/snntorch/surrogate.py
@@ -301,10 +301,11 @@ class Sigmoid(torch.autograd.Function):
     def backward(ctx, grad_output):
         (input_,) = ctx.saved_tensors
         grad_input = grad_output.clone()
-        # equivalent to slope * exp(-slope * input_) /
-        # (exp(-slope * input_) + 1) ** 2, but numerically stable:
-        # the exponential form overflows to inf / inf = nan once
-        # -slope * input_ exceeds ~88
+        # equivalent to
+        #   slope * exp(-slope * input_) / (exp(-slope * input_) + 1) ** 2
+        # but numerically stable:
+        # the exponential form overflows to inf / inf = nan once the absolute
+        # value of -slope * input_ exceeds ~88
         sig = torch.sigmoid(ctx.slope * input_)
         grad = grad_input * ctx.slope * sig * (1.0 - sig)
         return grad, None

--- a/snntorch/surrogate.py
+++ b/snntorch/surrogate.py
@@ -301,12 +301,12 @@ class Sigmoid(torch.autograd.Function):
     def backward(ctx, grad_output):
         (input_,) = ctx.saved_tensors
         grad_input = grad_output.clone()
-        grad = (
-            grad_input
-            * ctx.slope
-            * torch.exp(-ctx.slope * input_)
-            / ((torch.exp(-ctx.slope * input_) + 1) ** 2)
-        )
+        # equivalent to slope * exp(-slope * input_) /
+        # (exp(-slope * input_) + 1) ** 2, but numerically stable:
+        # the exponential form overflows to inf / inf = nan once
+        # -slope * input_ exceeds ~88
+        sig = torch.sigmoid(ctx.slope * input_)
+        grad = grad_input * ctx.slope * sig * (1.0 - sig)
         return grad, None
 
 

--- a/tests/test_snntorch/test_surrogate.py
+++ b/tests/test_snntorch/test_surrogate.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+
+"""Tests for surrogate gradients."""
+
+import pytest
+import torch
+from snntorch import surrogate
+
+
+class TestSigmoidSurrogate:
+    def test_sigmoid_backward_no_nan(self):
+        # issue #427: exp(-slope * input_) overflows to inf for
+        # slope * input_ < ~-88, giving inf / inf = nan gradients
+        x = torch.tensor([-5.0], requires_grad=True)
+        spk = surrogate.sigmoid()(x)
+        spk.backward()
+        assert torch.isfinite(x.grad).all()
+
+    @pytest.mark.parametrize("slope", [1, 25, 100])
+    def test_sigmoid_backward_finite_over_range(self, slope):
+        x = torch.linspace(-100, 100, 201, requires_grad=True)
+        spk = surrogate.sigmoid(slope=slope)(x)
+        spk.sum().backward()
+        assert torch.isfinite(x.grad).all()
+
+    def test_sigmoid_backward_matches_analytical(self):
+        # where the exponential form is stable, the rewritten gradient
+        # must agree with slope * exp(-slope*u) / (exp(-slope*u) + 1)**2.
+        # compared in float64 to keep the reference itself precise
+        slope = 25
+        x = torch.linspace(
+            -0.5, 0.5, 101, dtype=torch.float64, requires_grad=True
+        )
+        spk = surrogate.sigmoid(slope=slope)(x)
+        spk.sum().backward()
+
+        exp_term = torch.exp(-slope * x.detach())
+        expected = slope * exp_term / (exp_term + 1) ** 2
+        assert torch.allclose(x.grad, expected, rtol=1e-9, atol=1e-12)
+
+    def test_sigmoid_backward_saturates_to_zero(self):
+        x = torch.tensor([-1000.0, 1000.0], requires_grad=True)
+        spk = surrogate.sigmoid()(x)
+        spk.sum().backward()
+        assert torch.isfinite(x.grad).all()
+        assert torch.allclose(x.grad, torch.zeros_like(x.grad))

--- a/tests/test_snntorch/test_surrogate.py
+++ b/tests/test_snntorch/test_surrogate.py
@@ -10,7 +10,7 @@ from snntorch import surrogate
 class TestSigmoidSurrogate:
     def test_sigmoid_backward_no_nan(self):
         # issue #427: exp(-slope * input_) overflows to inf for
-        # slope * input_ < ~-88, giving inf / inf = nan gradients
+        # slope * input_ < ~-88 and gives inf / inf = nan gradients
         x = torch.tensor([-5.0], requires_grad=True)
         spk = surrogate.sigmoid()(x)
         spk.backward()
@@ -24,9 +24,8 @@ class TestSigmoidSurrogate:
         assert torch.isfinite(x.grad).all()
 
     def test_sigmoid_backward_matches_analytical(self):
-        # where the exponential form is stable, the rewritten gradient
-        # must agree with slope * exp(-slope*u) / (exp(-slope*u) + 1)**2.
-        # compared in float64 to keep the reference itself precise
+        # where the exponential form is stable, the rewritten gradient must
+        # agree with slope * exp(-slope * u) / (exp(-slope * u) + 1) ** 2
         slope = 25
         x = torch.linspace(
             -0.5, 0.5, 101, dtype=torch.float64, requires_grad=True
@@ -36,6 +35,7 @@ class TestSigmoidSurrogate:
 
         exp_term = torch.exp(-slope * x.detach())
         expected = slope * exp_term / (exp_term + 1) ** 2
+        # comparison uses float64 to keep the reference itself precise
         assert torch.allclose(x.grad, expected, rtol=1e-9, atol=1e-12)
 
     def test_sigmoid_backward_saturates_to_zero(self):


### PR DESCRIPTION
Fixes #427.

### Problem

`Sigmoid.backward` computes

```python
grad_input * slope * torch.exp(-slope * input_) / ((torch.exp(-slope * input_) + 1) ** 2)
```

`exp(-slope * input_)` overflows to `inf` once `-slope * input_` exceeds ~88, giving `inf / inf = nan`. With the default `slope=25`, any membrane potential more than ~3.5 below threshold silently produces `nan` gradients, which then poison the whole backward pass — exactly the "weird loss behaviours" described in #427.

### Change

Rewrite the gradient in the standard numerically stable form:

```python
sig = torch.sigmoid(ctx.slope * input_)
grad = grad_input * ctx.slope * sig * (1.0 - sig)
```

This is mathematically identical (`exp(-z)/(1+exp(-z))² = σ(z)(1−σ(z))`) and saturates to zero instead of overflowing.

### Tests

New `tests/test_snntorch/test_surrogate.py`:

- the exact repro from #427 (`x = -5.0`) yields finite gradients,
- finite gradients across `[-100, 100]` for slopes 1/25/100,
- agreement with the analytical exponential form in its stable region (compared in float64),
- gradient saturates to exactly zero at extreme inputs.

Full suite: 158 passed, 2 xfailed.
