### PR TITLE
Preserve input dtype in population code helpers

### DIFF
--- a/snntorch/functional/acc.py
+++ b/snntorch/functional/acc.py
@@ -94,7 +94,11 @@ def _population_code(spk_out, num_classes, num_outputs):
     # if spk_out.is_cuda:
     #     device = "cuda"
     device = spk_out.device
-    pop_code = torch.zeros(tuple([spk_out.size(1)] + [num_classes])).to(device)
+    pop_code = torch.zeros(
+        tuple([spk_out.size(1)] + [num_classes]),
+        dtype=spk_out.dtype,
+        device=device,
+    )
     for idx in range(num_classes):
         pop_code[:, idx] = (
             spk_out[

--- a/snntorch/functional/loss.py
+++ b/snntorch/functional/loss.py
@@ -42,8 +42,10 @@ class LossFunctions:
                 f"of num_classes {num_classes}."
             )
         device = spk_out.device
-        pop_code = torch.zeros(tuple([spk_out.size(1)] + [num_classes])).to(
-            device
+        pop_code = torch.zeros(
+            tuple([spk_out.size(1)] + [num_classes]),
+            dtype=spk_out.dtype,
+            device=device,
         )
         for idx in range(num_classes):
             pop_code[:, idx] = (

--- a/tests/test_snntorch/functional/test_acc.py
+++ b/tests/test_snntorch/functional/test_acc.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+
+"""Tests for accuracy metrics."""
+
+import torch
+
+from snntorch.functional import acc
+
+torch.manual_seed(42)
+
+
+class TestAcc:
+    def test_accuracy_rate(self):
+        spk_out = torch.zeros((5, 2, 4))
+        spk_out[:, 0, 0] = 1
+        spk_out[:, 1, 3] = 1
+        targets = torch.tensor([0, 3])
+
+        assert acc.accuracy_rate(spk_out, targets) == 1.0
+
+    def test_accuracy_rate_population_code(self):
+        spk_out = torch.zeros((5, 2, 4))
+        spk_out[:, 0, 0:2] = 1
+        spk_out[:, 1, 2:4] = 1
+        targets = torch.tensor([0, 1])
+
+        accuracy = acc.accuracy_rate(
+            spk_out, targets, population_code=True, num_classes=2
+        )
+
+        assert accuracy == 1.0
+
+    def test_accuracy_rate_population_code_dtype(self):
+        # float64 inputs should not be downcast, which would lose
+        # the ordering of close scores
+        spk_out = torch.tensor(
+            [[[1.00000002, 1.00000005]]], dtype=torch.float64
+        )
+        targets = torch.tensor([1])
+
+        pop_code = acc._population_code(spk_out, num_classes=2, num_outputs=2)
+        accuracy = acc.accuracy_rate(
+            spk_out, targets, population_code=True, num_classes=2
+        )
+
+        assert pop_code.dtype == torch.float64
+        assert accuracy == 1.0

--- a/tests/test_snntorch/functional/test_loss.py
+++ b/tests/test_snntorch/functional/test_loss.py
@@ -90,6 +90,20 @@ class TestLoss:
             unreduced_loss.mean().item(), reduced_loss.item()
         )
 
+    def test_ce_count_loss_population_code_dtype(self):
+        # population code should preserve the input dtype (float64)
+        loss_fn = sf.ce_count_loss(
+            population_code=True,
+            num_classes=2,
+            weight=torch.tensor([1.0, 2.0], dtype=torch.float64),
+        )
+        spike_predicted = torch.randn(4, 1, 4, dtype=torch.float64)
+        targets = torch.tensor([1])
+
+        loss = loss_fn(spike_predicted, targets)
+
+        assert loss.dtype == torch.float64
+
     def test_ce_count_loss_weighted(
         self, spike_predicted_, targets_labels_, class_weights_
     ):


### PR DESCRIPTION
Fixes #429, and the `ce_count_loss` float64 case from #428.

`_population_code` in both `snntorch/functional/acc.py` and `snntorch/functional/loss.py` allocates its accumulator with `torch.zeros(...)`, which always produces float32 regardless of the input dtype. This causes two problems with float64 inputs:

1. **Silent precision loss in `accuracy_rate`**: close float64 scores are downcast to float32, which can collapse them to equal values and flip the predicted class (the reproduction in #429 reports 0.0 accuracy when the target class has the strictly larger score).
2. **`RuntimeError` in `ce_count_loss(population_code=True)`**: the float32 population code is passed to `NLLLoss` alongside float64 class weights, raising `expected scalar type Float but found Double`.

The fix allocates the accumulator with `dtype=spk_out.dtype` (and passes `device=` directly instead of the extra `.to(device)` copy) so the population code always matches the input.

Added regression tests for both cases:
- `test_accuracy_rate_population_code_dtype`: checks that close float64 scores keep their ordering and the accuracy is scored correctly, plus a couple of basic `accuracy_rate` tests since `acc.py` had no coverage before.
- `test_ce_count_loss_population_code_dtype`: checks that population-coded `ce_count_loss` works with float64 inputs/weights and returns a float64 loss.

Full test suite passes locally (150 passed + NIR tests), and the changed files are formatted with black. float32 behavior is unchanged.

Made with [Cursor](https://cursor.com)