### PR TITLE
Fix LeakyParallel silently ignoring a per-neuron beta; correct the reset=zero formula in Leaky

### DIFF
--- a/snntorch/_neurons/leaky.py
+++ b/snntorch/_neurons/leaky.py
@@ -17,12 +17,13 @@ class Leaky(LIF):
 
             U[t+1] = βU[t] + I_{\\rm in}[t+1] - RU_{\\rm thr}
 
-    If `reset_mechanism = "zero"`, then :math:`U[t+1]` will be set to `0`
-    whenever the neuron emits a spike:
+    If `reset_mechanism = "zero"`, then :math:`U[t]` is set to `0` whenever
+    the neuron emitted a spike on the previous step, before the new input
+    is integrated:
 
     .. math::
 
-            U[t+1] = βU[t] + I_{\\rm syn}[t+1] - R(βU[t] + I_{\\rm in}[t+1])
+            U[t+1] = β(1-R)U[t] + I_{\\rm in}[t+1]
 
     * :math:`I_{\\rm in}` - Input current
     * :math:`U` - Membrane potential

--- a/snntorch/_neurons/leakyparallel.py
+++ b/snntorch/_neurons/leakyparallel.py
@@ -291,15 +291,29 @@ class LeakyParallel(nn.Module):
                 elif isinstance(self.beta, torch.Tensor) or isinstance(
                     self.beta, torch.FloatTensor
                 ):
+                    # `_beta_buffer` always stores beta as a tensor, so the
+                    # length checks must be nested inside this branch --
+                    # they were previously siblings of this `elif`, which
+                    # made the per-neuron (`len == hidden_size`) path and
+                    # the `ValueError` unreachable, so a per-neuron beta
+                    # was dropped silently and `weight_hh_l0` kept its
+                    # random RNN initialization.
                     if len(self.beta) == 1:
                         self.rnn.weight_hh_l0.fill_(self.beta[0])
-                elif len(self.beta) == self.hidden_size:
-                    # Replace each value with the corresponding value in self.beta
-                    for i in range(self.hidden_size):
-                        self.rnn.weight_hh_l0.data[i].fill_(self.beta[i])
+                    elif len(self.beta) == self.hidden_size:
+                        # Replace each value with the corresponding value
+                        # in self.beta
+                        for i in range(self.hidden_size):
+                            self.rnn.weight_hh_l0.data[i].fill_(self.beta[i])
+                    else:
+                        raise ValueError(
+                            "Beta must be either a single value or of "
+                            "length 'hidden_size'."
+                        )
                 else:
-                    raise ValueError(
-                        "Beta must be either a single value or of length 'hidden_size'."
+                    raise TypeError(
+                        "Beta must be a float, int, or torch.Tensor; "
+                        f"got {type(self.beta)}."
                     )
 
     def _beta_buffer(self, beta, learn_beta):

--- a/tests/test_snntorch/test_leakyparallel.py
+++ b/tests/test_snntorch/test_leakyparallel.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+
+"""Tests for LeakyParallel neuron."""
+
+import pytest
+import snntorch as snn
+import torch
+
+
+class TestLeakyParallel:
+    def test_leakyparallel_scalar_beta_sets_diagonal(self):
+        lp = snn.LeakyParallel(input_size=4, hidden_size=6, beta=0.42)
+        diag = torch.diagonal(lp.rnn.weight_hh_l0.detach())
+        assert torch.allclose(diag, torch.full((6,), 0.42), atol=1e-6)
+
+    def test_leakyparallel_per_neuron_beta_sets_diagonal(self):
+        """Regression: a per-neuron ``beta`` (length == hidden_size) must be
+        written to the diagonal of ``weight_hh_l0``. It was previously
+        dropped silently -- the length check was unreachable -- so the
+        layer kept the RNN's random recurrent init."""
+        beta = torch.linspace(0.1, 0.9, 6)
+        lp = snn.LeakyParallel(input_size=4, hidden_size=6, beta=beta)
+        whh = lp.rnn.weight_hh_l0.detach()
+        assert torch.allclose(torch.diagonal(whh), beta, atol=1e-6)
+        # weight_hh is forced diagonal by default
+        off_diag = whh - torch.diag(torch.diagonal(whh))
+        assert off_diag.abs().max().item() == 0.0
+
+    def test_leakyparallel_length_one_beta_tensor(self):
+        lp = snn.LeakyParallel(
+            input_size=4, hidden_size=6, beta=torch.tensor([0.3])
+        )
+        diag = torch.diagonal(lp.rnn.weight_hh_l0.detach())
+        assert torch.allclose(diag, torch.full((6,), 0.3), atol=1e-6)
+
+    def test_leakyparallel_bad_beta_length_raises(self):
+        with pytest.raises(ValueError):
+            snn.LeakyParallel(
+                input_size=4, hidden_size=6, beta=torch.tensor([0.3, 0.4])
+            )
+
+    def test_leakyparallel_per_neuron_beta_drives_recurrence(self):
+        """With ``weight_hh`` diagonal, the per-neuron beta *is* the
+        recurrent decay. Two layers identical except for beta -- inputs,
+        ``weight_ih`` and both biases shared -- must produce different
+        outputs. Without the per-neuron beta being written, both layers
+        run at the same (default) recurrent weights and this fails."""
+        torch.manual_seed(0)
+        x = torch.rand(8, 2, 4) * 3.0
+        a = snn.LeakyParallel(
+            input_size=4, hidden_size=6, beta=torch.full((6,), 0.05)
+        )
+        b = snn.LeakyParallel(
+            input_size=4, hidden_size=6, beta=torch.full((6,), 0.95)
+        )
+        b.load_state_dict(a.state_dict())  # copy everything...
+        b._beta_buffer(torch.full((6,), 0.95), learn_beta=False)
+        b._beta_to_weight_hh()  # ...then set only b's recurrent weights from its beta
+        with torch.no_grad():
+            assert not torch.equal(a(x), b(x))


### PR DESCRIPTION
Fixes #442.

### Problem

**1. `LeakyParallel` silently drops a per-neuron `beta`.**

`_beta_to_weight_hh` walks an `if / elif / elif / else` chain:

```python
if isinstance(self.beta, float) or isinstance(self.beta, int):
    self.rnn.weight_hh_l0.fill_(self.beta)
elif isinstance(self.beta, torch.Tensor) or isinstance(self.beta, torch.FloatTensor):
    if len(self.beta) == 1:
        self.rnn.weight_hh_l0.fill_(self.beta[0])
elif len(self.beta) == self.hidden_size:          # sibling of the Tensor elif
    for i in range(self.hidden_size):
        self.rnn.weight_hh_l0.data[i].fill_(self.beta[i])
else:
    raise ValueError(...)
```

`_beta_buffer` always stores `beta` as a `torch.Tensor`, so control always
enters the second branch, and only its inner `if len(self.beta) == 1` is
reachable. The `elif len(self.beta) == self.hidden_size` (the per-neuron path)
**and** the `else: raise ValueError` are dead.

Passing `beta=<tensor of length hidden_size>` — which the docstring explicitly
supports (*"multi-valued (one weight per neuron)"*) — leaves
`rnn.weight_hh_l0` at its **random RNN initialisation**, with no error. The
layer then trains and runs with arbitrary recurrent decay rates. A
wrong-length `beta` is likewise accepted silently.

```python
import torch, snntorch as snn
lp = snn.LeakyParallel(input_size=4, hidden_size=6, beta=torch.linspace(0.1, 0.9, 6))
torch.diagonal(lp.rnn.weight_hh_l0)
# tensor([ 0.131, 0.136, -0.121, -0.028, 0.308, 0.287])   <- random init, not the betas
snn.LeakyParallel(input_size=4, hidden_size=6, beta=torch.tensor([0.3, 0.4]))
# no error
```

**Reproduce (before this PR):**

![reproduce](https://raw.githubusercontent.com/tritsystem/snntorch/media/bug-before.gif)

**2. `Leaky` docstring — `reset_mechanism="zero"` formula is wrong.**

It states `U[t+1] = βU[t] + I_syn[t+1] - R(βU[t] + I_in[t+1])`, i.e.
`(1-R)(βU[t] + I)`, which is `0` on the step after a spike *regardless of
input*. The implementation (`_base_zero`) is standard reset-then-integrate,
`U[t+1] = β(1-R)U[t] + I_in[t+1]`, which equals `I_in` on that step (verified
against a hand-rolled reference — matches to `0.0`). `Leaky` also has no
synaptic current, so `I_syn` is a copy-paste from `Synaptic`.

### Changes

- `snntorch/_neurons/leakyparallel.py` — nest the two length checks and the
  `ValueError` inside the `torch.Tensor` branch so the per-neuron path is
  reached; an unsupported `beta` type now raises `TypeError` instead of
  falling through.
- `snntorch/_neurons/leaky.py` — fix the `reset_mechanism="zero"` formula and
  drop the stray `I_syn`.

### Tests

New `tests/test_snntorch/test_leakyparallel.py` (5 tests). Three fail on
`master` without this change:

| test | on master |
|---|---|
| scalar `beta` fills the diagonal | pass |
| **per-neuron `beta` (len == hidden_size) written to the diagonal** | **fail** |
| length-1 `beta` tensor still works | pass |
| **wrong-length `beta` raises `ValueError`** | **fail** (silently accepted) |
| **two layers identical but for a per-neuron `beta` give different output** | **fail** (both ran at default recurrent weights) |

Full suite: `195 → 200 passed, 2 xfailed`.

**After this PR:**

![after fix](https://raw.githubusercontent.com/tritsystem/snntorch/media/bug-after.gif)

### Checklist

- [x] Applied `flake8` and `black` (changed files clean; `flake8 --select=E9,F63,F7,F82` clean)
- [x] Implemented unit tests and they all pass
