### PR TITLE
Fix SpikingNeuron.zeros() being a no-op; keep it leaf-tensor safe

### DIFF
--- a/snntorch/_neurons/neurons.py
+++ b/snntorch/_neurons/neurons.py
@@ -225,7 +225,15 @@ class SpikingNeuron(nn.Module):
         """Used to clear hidden state variables to zero.
         Intended for use where hidden state variables are global variables."""
         for state in args:
-            state = torch.zeros_like(state)
+            # `state = torch.zeros_like(state)` only rebinds the local
+            # loop name, leaving the caller's tensor untouched. Zero the
+            # storage in place instead. `.detach()` (a storage-sharing
+            # view) is used rather than a bare `state.zero_()` so this
+            # also works on a grad-requiring leaf -- e.g. an
+            # `init_leaky()` hidden state reset before the first forward
+            # pass, where `state.zero_()` would raise "a leaf Variable
+            # that requires grad is being used in an in-place operation".
+            state.detach().zero_()
 
     @staticmethod
     def _surrogate_bypass(input_):

--- a/tests/test_snntorch/test_zeros.py
+++ b/tests/test_snntorch/test_zeros.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+
+"""Tests for SpikingNeuron.zeros (issue #423)."""
+
+import torch
+import snntorch as snn
+from snntorch._neurons.neurons import SpikingNeuron
+
+
+class TestSpikingNeuronZeros:
+    def test_zeros_clears_a_plain_tensor_in_place(self):
+        """It was a no-op: ``state = torch.zeros_like(state)`` only rebinds
+        the loop variable. It must zero the caller's tensor in place."""
+        t = torch.ones(3, 4)
+        ptr = t.data_ptr()
+        SpikingNeuron.zeros(t)
+        assert torch.equal(t, torch.zeros_like(t))
+        assert t.data_ptr() == ptr  # same storage, not a new tensor
+
+    def test_zeros_multiple_args(self):
+        t1 = torch.ones(3)
+        t2 = torch.full((2, 2), 5.0)
+        SpikingNeuron.zeros(t1, t2)
+        assert torch.equal(t1, torch.zeros_like(t1))
+        assert torch.equal(t2, torch.zeros_like(t2))
+
+    def test_zeros_clears_hidden_state_after_forward(self):
+        lif = snn.Leaky(beta=0.5, init_hidden=True)
+        _ = lif(torch.ones(2, 4))
+        assert (lif.mem != 0).any()
+        SpikingNeuron.zeros(lif.mem)
+        assert torch.equal(lif.mem, torch.zeros_like(lif.mem))
+
+    def test_zeros_on_grad_requiring_leaf(self):
+        """Resetting hidden state to zero *before* the first forward pass
+        is a normal training pattern. At that point the state is a
+        grad-requiring leaf, and a bare ``state.zero_()`` raises
+        ``RuntimeError: a leaf Variable that requires grad is being used
+        in an in-place operation``. ``zeros()`` must handle it and leave
+        ``requires_grad`` unchanged."""
+        mem = torch.ones(2, 4, requires_grad=True)  # non-zero grad-leaf
+        assert mem.is_leaf and mem.requires_grad
+
+        SpikingNeuron.zeros(mem)
+
+        assert torch.equal(mem, torch.zeros(2, 4))
+        assert mem.requires_grad  # untouched
+        assert mem.grad is None


### PR DESCRIPTION
Fixes #423. Supersedes #424 (same root cause; adds leaf-tensor handling + a test for it).

### Problem

`SpikingNeuron.zeros(*args)` is documented to *"clear hidden state variables to zero"*, but it does nothing:

```python
for state in args:
    state = torch.zeros_like(state)
```

`state = ...` only rebinds the local loop variable — the tensor the caller passed in is never touched. `SpikingNeuron.zeros(...)` is a complete no-op.

The obvious fix, `state.zero_()` (proposed in #424), is correct for a tensor that has already been through a forward pass, but **raises on a grad-requiring leaf**:

```python
import torch
mem = torch.ones(2, 4, requires_grad=True)   # an init_leaky() hidden state, pre-first-forward
mem.zero_()
# RuntimeError: a leaf Variable that requires grad is being used in an in-place operation.
```

Resetting hidden state to zero at the start of an episode/batch, *before* the first forward call, is a normal training pattern — and it's the case `zeros()` is most likely to be used in.

![reproduce](https://raw.githubusercontent.com/tritsystem/snntorch/media-zeros/bug-before.gif)

### Fix

```python
state.detach().zero_()
```

`.detach()` returns a view over the same storage, so this still zeros in place; it just sidesteps the leaf-tensor autograd restriction. `requires_grad` on the caller's tensor is left unchanged. This also mirrors the sibling `detach()` method directly above, which already mutates in place (`state.detach_()`).

![after fix](https://raw.githubusercontent.com/tritsystem/snntorch/media-zeros/bug-after.gif)

### Changes

- `snntorch/_neurons/neurons.py` — `SpikingNeuron.zeros` now zeros the passed tensors in place via `state.detach().zero_()`.

### Tests

New `tests/test_snntorch/test_zeros.py` (4 tests — **all fail on `master`**):

| test | on master |
|---|---|
| zeros a plain tensor in place (same `data_ptr`, i.e. not a rebind) | fail (no-op) |
| handles multiple `*args` | fail (no-op) |
| clears a `Leaky(init_hidden=True)` hidden state after a forward pass | fail (no-op) |
| clears a **non-zero grad-requiring leaf** and leaves `requires_grad` untouched | fail (no-op) — and the `state.zero_()` approach would raise here |

Full suite: `195 → 199 passed, 2 xfailed`.

### Checklist

- [x] Applied `black` and `flake8` (changed lines clean; `flake8 --select=E9,F63,F7,F82` clean)
- [x] Implemented unit tests and they all pass
