### PR TITLE
Fix state_quant to preserve the input tensor's dtype

### DIFF
--- a/snntorch/functional/quant.py
+++ b/snntorch/functional/quant.py
@@ -9,7 +9,7 @@ class StateQuant(torch.autograd.Function):
     def forward(ctx, input_, levels):
 
         device = input_.device
-        levels = levels.to(device)
+        levels = levels.to(device=device, dtype=input_.dtype)
         size = input_.size()
         input_ = input_.flatten()
 

--- a/tests/test_snntorch/functional/test_quant_dtype.py
+++ b/tests/test_snntorch/functional/test_quant_dtype.py
@@ -1,0 +1,41 @@
+"""Tests for dtype preservation in spikegen.latency (#440) and
+functional.quant.state_quant (#439)."""
+
+import pytest
+import torch
+
+from snntorch import spikegen
+from snntorch.functional import quant
+
+
+@pytest.mark.parametrize(
+    "dtype", [torch.float32, torch.float64, torch.float16, torch.bfloat16]
+)
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {},
+        {"normalize": True},
+        {"linear": True, "normalize": True},
+        {"interpolate": True, "normalize": True},
+    ],
+    ids=["default", "normalize", "linear+normalize", "interpolate+normalize"],
+)
+def test_latency_preserves_dtype(dtype, kwargs):
+    x = torch.tensor([0.2, 0.8], dtype=dtype)
+    out = spikegen.latency(x, num_steps=5, **kwargs)
+    assert out.dtype == dtype
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+@pytest.mark.parametrize("uniform", [True, False], ids=["uniform", "nonuniform"])
+@pytest.mark.parametrize("thr_centered", [True, False])
+def test_state_quant_preserves_dtype(dtype, uniform, thr_centered):
+    x = torch.tensor([0.125, 0.875], dtype=dtype)
+    q = quant.state_quant(
+        num_bits=4, uniform=uniform, thr_centered=thr_centered, threshold=1.0
+    )
+    out = q(x)
+    assert out.dtype == dtype
+    # values must still be valid quantization levels
+    assert out.numel() == x.numel()

--- a/tests/test_snntorch/functional/test_quant_dtype.py
+++ b/tests/test_snntorch/functional/test_quant_dtype.py
@@ -1,30 +1,9 @@
-"""Tests for dtype preservation in spikegen.latency (#440) and
-functional.quant.state_quant (#439)."""
+"""Tests for dtype preservation in functional.quant.state_quant (#439)."""
 
 import pytest
 import torch
 
-from snntorch import spikegen
 from snntorch.functional import quant
-
-
-@pytest.mark.parametrize(
-    "dtype", [torch.float32, torch.float64, torch.float16, torch.bfloat16]
-)
-@pytest.mark.parametrize(
-    "kwargs",
-    [
-        {},
-        {"normalize": True},
-        {"linear": True, "normalize": True},
-        {"interpolate": True, "normalize": True},
-    ],
-    ids=["default", "normalize", "linear+normalize", "interpolate+normalize"],
-)
-def test_latency_preserves_dtype(dtype, kwargs):
-    x = torch.tensor([0.2, 0.8], dtype=dtype)
-    out = spikegen.latency(x, num_steps=5, **kwargs)
-    assert out.dtype == dtype
 
 
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float64])


### PR DESCRIPTION
### Problem

`snntorch.functional.quant.state_quant` silently returns `float32` tensors for `float64` inputs, with both uniform and non-uniform quantization (#439). This causes precision loss or dtype mismatches when quantizing the double-precision hidden states of a model converted with `.double()`.

### Root cause

The quantization levels are created with `torch.linspace(...)` / `torch.tensor(...)` without a dtype, so they default to `float32`. In `StateQuant.forward`, the levels are only moved to the input device:

```python
levels = levels.to(device)
```

They are never converted to the input dtype, and the returned tensor is selected directly from those levels (`levels[idx_match]`), so it inherits the hard-coded `float32`.

### Fix

Convert the levels to the input dtype while moving them to the input device:

```python
levels = levels.to(device=device, dtype=input_.dtype)
```

Dtype-agnostic and device-agnostic: no-op for `float32` inputs (today's behavior), preserves `float64` (and any other floating dtype) everywhere.

### Verification

* Issue reproduction: a `float64` input now returns `float64` for uniform, non-uniform `thr_centered=True`, and non-uniform `thr_centered=False` quantization.
* Quantized values are unchanged vs `float32` inputs (same nearest levels selected); straight-through-estimator gradients still flow with the input dtype (`grad.dtype == float64`).
* New regression tests in `tests/test_snntorch/functional/test_quant_dtype.py` (3 quantization modes x {float32, float64}).
* Cross-device check on Ascend NPU (torch 2.14.0a0 + torch_npu, 910B): dtype preserved on `npu:0` for `float32`. (`float64` on Ascend is limited by torch_npu's `aclnnMinDim` dtype support — identical behavior before and after this change, i.e. not introduced here.)

Fixes #439
