### PR TITLE
fix(utils): scope reset(net) to the given network instead of all instances

### DIFF
--- a/snntorch/utils.py
+++ b/snntorch/utils.py
@@ -141,9 +141,16 @@ def valid_split(ds_train, ds_val, split, seed=0):
 
 
 def reset(net):
-    """Check for the types of LIF neurons contained in net.
-    Reset their hidden parameters to zero and detach them
-    from the current computation graph."""
+    """Reset the hidden states (and detach them from the computation graph)
+    of every snnTorch neuron contained in ``net``.
+
+    Only the neurons that actually belong to ``net`` are touched, so calling
+    :func:`reset` on one network never clears the hidden states of a separate
+    network that happens to use the same neuron class.
+
+    :param net: Network (or module) containing snnTorch neuron layers.
+    :type net: torch.nn.Module
+    """
 
     global is_alpha
     global is_leaky
@@ -167,7 +174,14 @@ def reset(net):
 
     _layer_check(net=net)
 
-    _layer_reset()
+    # Reset hidden states by iterating over the modules in *net* directly,
+    # rather than via the class-level reset_hidden (which iterates over
+    # cls.instances — i.e. ALL instances of that class across all networks).
+    for module in net.modules():
+        if isinstance(module, (snn.Lapicque, snn.Synaptic, snn.Leaky,
+                               snn.Alpha, snn.RLeaky, snn.RSynaptic,
+                               snn.SConv2dLSTM, snn.SLSTM)):
+            module.reset_mem()
 
 
 def _layer_check(net):


### PR DESCRIPTION
## Problem

`utils.reset(net)` calls class-level `reset_hidden()` methods on every neuron type found in `net`. Those methods iterate over `cls.instances` — a class-level registry of **all** instances of that neuron class, not just the ones belonging to `net`. As a result, calling `utils.reset(net_a)` also clears the hidden states of a completely separate `net_b` when both networks contain the same neuron class.

## Root cause

`reset()` → `_layer_check(net)` → `_layer_reset()`. The `_layer_reset()` function calls `snn.Leaky.reset_hidden()` (and similar for other neuron types), which is a `@classmethod` that iterates over `cls.instances` — the global list of every instance created for that neuron class. This makes the reset a global operation, not scoped to the supplied network.

## Fix

Replace the class-level `_layer_reset()` call with a direct iteration over `net.modules()`, calling the instance-level `reset_mem()` on each snnTorch neuron found. This keeps the reset correctly scoped to the modules that actually belong to the supplied network.

The module-level globals and `_layer_check()` are preserved so that `backprop.py` (which reads them after `reset()` returns) continues to work unchanged.

## Verification

1. Reproduced the bug on Ascend NPU (torch 2.14.0a0): `reset(net_a)` cleared `net_b`'s hidden states
2. Verified the fix: `reset(net_a)` resets `net_a` to zero while preserving `net_b`'s hidden states
3. Regression test: forward+backward+step+reset loop works correctly
4. Only 1 file changed (`snntorch/utils.py`), 18 insertions, 4 deletions