### PR TITLE
fix(population_code): preserve input dtype in population-code helpers

### DIFF
--- a/snntorch/functional/acc.py
+++ b/snntorch/functional/acc.py
@@ -94,7 +94,7 @@ def _population_code(spk_out, num_classes, num_outputs):
     # if spk_out.is_cuda:
     #     device = "cuda"
     device = spk_out.device
-    pop_code = torch.zeros(tuple([spk_out.size(1)] + [num_classes])).to(device)
+    pop_code = torch.zeros(tuple([spk_out.size(1)] + [num_classes]), dtype=spk_out.dtype).to(device)
     for idx in range(num_classes):
         pop_code[:, idx] = (
             spk_out[

--- a/snntorch/functional/loss.py
+++ b/snntorch/functional/loss.py
@@ -42,7 +42,7 @@ class LossFunctions:
                 f"of num_classes {num_classes}."
             )
         device = spk_out.device
-        pop_code = torch.zeros(tuple([spk_out.size(1)] + [num_classes])).to(
+        pop_code = torch.zeros(tuple([spk_out.size(1)] + [num_classes]), dtype=spk_out.dtype).to(
             device
         )
         for idx in range(num_classes):
@@ -105,7 +105,7 @@ class ce_rate_loss(LossFunctions):
         log_softmax_fn = nn.LogSoftmax(dim=-1)
 
         if self.population_code:
-            pop_code = torch.zeros((num_steps, spk_out.size(1), self.num_classes)).to(device)
+            pop_code = torch.zeros((num_steps, spk_out.size(1), self.num_classes), dtype=spk_out.dtype).to(device)
             for idx in range(self.num_classes):
                 pop_code[:, :, idx] = spk_out[
                     :,
@@ -120,7 +120,7 @@ class ce_rate_loss(LossFunctions):
             
         log_p_y = log_softmax_fn(spk_out)
         loss_shape = (spk_out.size(1)) if self._intermediate_reduction() == 'none' else (1)
-        loss = torch.zeros(loss_shape, dtype=dtype, device=device)
+        loss = torch.zeros(loss_shape, dtype=spk_out.dtype, device=device)
 
         for step in range(num_steps):
             loss += loss_fn(log_p_y[step], targets)


### PR DESCRIPTION
Fix two issues where snnTorch population-code helpers fail with float64 inputs or weights.

**Problem**: The population-code helpers in loss.py and acc.py use hardcoded float32 dtype when creating internal tensors (pop_code accumulators, loss accumulators), even when the input tensor or class weights are float64. This causes:

1. ce_rate_loss() and ce_count_loss() with population_code=True raise RuntimeError: expected scalar type Float but found Double when float64 weights or inputs are provided (issue #428).
2. accuracy_rate() with population_code=True loses precision on close float64 scores, reporting the wrong class (issue #429).

**Root cause**: 
- torch.zeros(..., dtype=torch.float) hardcodes float32 (dtype = torch.float at module level).
- _population_code in both loss.py and acc.py creates torch.zeros(...) with default float32 dtype instead of matching the input's dtype.

**Fix**: Use spk_out.dtype when creating pop_code and loss accumulators, preserving the input's dtype throughout the population-code path. Changes:
- loss.py: _population_code() pop_code tensor, ce_rate_loss._compute_loss() pop_code and loss accumulator - all now use spk_out.dtype
- acc.py: _population_code() pop_code tensor - now uses spk_out.dtype

**Verification** (on Ascend NPU with torch 2.14):
- Case 1: ce_rate_loss(population_code=True, num_classes=2) with default weight=None - OK
- Case 2: ce_rate_loss() with float64 weights + float64 inputs - returns float64 loss
- Case 3: ce_count_loss() with float64 weights + float64 inputs - returns float64 loss  
- Case 4: accuracy_rate(population_code=True) on close float64 scores - correct class (accuracy=1.0)
- All 21 existing loss tests pass on NPU without regression.

Fixes #428, #429